### PR TITLE
DateDynamic - fix leading 0s when input is 'now'

### DIFF
--- a/src/components/SukohForm/components/DateDynamic.js
+++ b/src/components/SukohForm/components/DateDynamic.js
@@ -25,7 +25,7 @@ class DateDynamic extends BaseDynamic {
     if(state[key]==='now')
     {
       let date = new Date();
-      state[key] = '' + date.getFullYear() + '-' + (date.getMonth() + 1) + '-' +  date.getDate();
+      state[key] = date.toISOString().split('T')[0];
     }
   }
 


### PR DESCRIPTION
Tiny patch for the `date` form

Currently (assuming a current date of Oct 3rd 2024):
 1. Manual `now` input in the form returns an output of `2024-10-3`, without leading zeroes (here, `3` instead of `03`);
 2. Trying to use this output in Hugo (e.g. for [displaying via `time.AsTime` and `time.Format`](https://gohugo.io/methods/time/format/)) yields error `error calling AsTime: unable to parse date: 2024-10-3`.

With change:
 1. `now` outputs ISO compliant date string, leading zeroes included.
 2. Hugo happy??
