### PR TITLE
refactor: remove dependency on @electron/remote. 

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -261,16 +261,10 @@ export class API {
   }
 
   /**
-   * Opens a file dialog and copies selected files into a collection item.
+   * Opens a file dialog and uploads selected files into a collection item.
    *
-   * TODO: Refactor to use HTML5 <input type="file"> per NEXTSTEPS.md
-   * This currently requires @electron/remote which breaks with contextIsolation.
-   * The proper fix is to use HTML5 file inputs in the calling components:
-   * - SelectImagesDialog.tsx
-   * - CollectionItem.tsx
-   * - Single.tsx
-   *
-   * @deprecated Use HTML5 file inputs instead
+   * Uses HTML5 file inputs for cross-platform compatibility (works in both Electron and browser mode).
+   * Files are read as base64 and uploaded via the uploadFileToBundlePath API.
    */
   openFileDialogForSingleAndCollectionItem(
     siteKey: string,
@@ -278,45 +272,89 @@ export class API {
     collectionKey: string,
     collectionItemKey: string,
     targetPath: string,
-    { title, extensions }:{title: string, extensions: Array<string>},
+    { title: _title, extensions }:{title: string, extensions: Array<string>},
     forceFileName?: string
   ){
+    return new Promise<void>((resolve, reject) => {
+      // Create hidden file input
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.multiple = !forceFileName; // Single file if forceFileName is set
+      input.accept = extensions.map(ext => `.${ext}`).join(',');
 
-    let properties = ['openFile'];
-    if(!forceFileName){
-      properties = ['multiSelections', 'openFile'];
-    }
+      input.onchange = async (e) => {
+        const files = (e.target as HTMLInputElement).files;
+        if (!files || files.length === 0) {
+          resolve();
+          return;
+        }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const remote = (window as any).require('@electron/remote');
+        try {
+          let newCollectionItemKey: string | undefined;
 
-    const openDialogOptions = {
-      title: title || 'Select Files',
-      properties: properties,
-      filters: [ {name:'Allowed Extensions', extensions: extensions }]
-    };
+          // Upload each selected file
+          for (const file of Array.from(files)) {
+            // Read file as base64
+            const base64Content = await new Promise<string>((res, rej) => {
+              const reader = new FileReader();
+              reader.onload = () => {
+                const result = reader.result as string;
+                // Remove data URL prefix (e.g., "data:image/png;base64,")
+                res(result.split(',')[1]);
+              };
+              reader.onerror = rej;
+              reader.readAsDataURL(file);
+            });
 
-    return (
+            // Determine filename
+            const filename = forceFileName
+              ? `${forceFileName}.${file.name.split('.').pop()}`
+              : file.name;
 
-      new Promise((resolve)=>{
-
-        remote.dialog.showOpenDialog(
-          remote.getCurrentWindow(),
-          openDialogOptions,
-        ).then((result)=>{
-          if(result.filePaths){
-            const files = result.filePaths;
-            resolve(
-              mainProcessBridge.request('copyFilesIntoCollectionItem', {siteKey, workspaceKey, collectionKey, collectionItemKey, targetPath, files, forceFileName })
+            // Upload to backend via base64
+            const result = await this.uploadFileToBundlePath(
+              siteKey,
+              workspaceKey,
+              collectionKey,
+              collectionItemKey,
+              targetPath,
+              filename,
+              base64Content
             );
+
+            // Track if item was converted to bundle
+            if (result.newCollectionItemKey) {
+              newCollectionItemKey = result.newCollectionItemKey;
+            }
           }
-        }).catch(err => {
-          this.logToConsole(err, 'copyFilesIntoCollectionItemFromDialog error');
-        });
 
-      })
+          // If item was converted to bundle, redirect to the new URL
+          if (newCollectionItemKey) {
+            const newUrl = `/workspace/${siteKey}/${workspaceKey}/collection/${collectionKey}/item/${encodeURIComponent(newCollectionItemKey)}`;
+            window.location.href = newUrl;
+          }
 
-    );
+          resolve();
+        } catch (error) {
+          console.error('Error uploading files:', error);
+          this.logToConsole(error, 'File upload error');
+          reject(error);
+        } finally {
+          // Cleanup
+          document.body.removeChild(input);
+        }
+      };
+
+      input.oncancel = () => {
+        document.body.removeChild(input);
+        resolve();
+      };
+
+      // Add to DOM (required for some browsers) and trigger
+      input.style.display = 'none';
+      document.body.appendChild(input);
+      input.click();
+    });
   }
   quiqr_git_repo_show(url: string){
     return mainProcessBridge.request('quiqr_git_repo_show', {url}, {timeout: 300000});
@@ -366,7 +404,7 @@ export class API {
       targetPath,
       filename,
       base64Content
-    }) as Promise<string>;
+    }) as Promise<{ uploadedPath: string; newCollectionItemKey?: string }>;
   }
 
   deleteFileFromBundle(

--- a/frontend/src/components/SukohForm/fields/BundleManagerField.tsx
+++ b/frontend/src/components/SukohForm/fields/BundleManagerField.tsx
@@ -133,7 +133,7 @@ function BundleManagerField({ compositeKey }: Props) {
 
       try {
         // Upload file to bundle
-        const uploadedPath = await service.api.uploadFileToBundlePath(
+        const result = await service.api.uploadFileToBundlePath(
           meta.siteKey,
           meta.workspaceKey,
           meta.collectionKey,
@@ -143,12 +143,19 @@ function BundleManagerField({ compositeKey }: Props) {
           base64Content
         );
 
+        // If item was converted to bundle, redirect to the new URL
+        if (result.newCollectionItemKey) {
+          const newUrl = `/workspace/${meta.siteKey}/${meta.workspaceKey}/collection/${meta.collectionKey}/item/${encodeURIComponent(result.newCollectionItemKey)}`;
+          window.location.href = newUrl;
+          return; // Exit early since we're redirecting
+        }
+
         // Check if file already exists in list
-        const match = currentFiles.find(x => x.src === uploadedPath);
+        const match = currentFiles.find(x => x.src === result.uploadedPath);
         if (match) {
           if (match.__deleted) delete match.__deleted;
         } else {
-          currentFiles.push({ src: uploadedPath });
+          currentFiles.push({ src: result.uploadedPath });
         }
       } catch (error) {
         console.error('Error uploading file:', error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "frontend"
       ],
       "dependencies": {
-        "@electron/remote": "^2.1.3",
         "7zip-bin": "3.1.0",
         "adm-zip": "0.4.13",
         "await-spawn": "4.0.1",
@@ -2074,6 +2073,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
       "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -2095,6 +2095,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2109,6 +2110,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2118,6 +2120,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -2227,15 +2230,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@electron/remote": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.1.3.tgz",
-      "integrity": "sha512-XlpxC8S4ttj/v2d+PKp9na/3Ev8bV7YWNL7Cw5b9MAWgTphEml7iYgbc7V0r9D6yDOfOkj06bchZgOZdlWJGNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "electron": ">= 13.0.0"
       }
     },
     "node_modules/@electron/universal": {
@@ -6155,6 +6149,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6190,6 +6185,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
@@ -6410,6 +6406,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
@@ -6536,6 +6533,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/http-errors": {
@@ -6573,6 +6571,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6688,6 +6687,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6751,6 +6751,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8140,6 +8141,7 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -8227,6 +8229,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -8394,6 +8397,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
@@ -8403,6 +8407,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -8421,6 +8426,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -8799,6 +8805,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -9238,6 +9245,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -9253,6 +9261,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9294,6 +9303,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9303,6 +9313,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9321,6 +9332,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9386,6 +9398,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9640,6 +9653,7 @@
       "version": "39.2.7",
       "resolved": "https://registry.npmjs.org/electron/-/electron-39.2.7.tgz",
       "integrity": "sha512-KU0uFS6LSTh4aOIC3miolcbizOFP7N1M46VTYVfqIgFiuA2ilfNaOHLDS9tCMvwwHRowAsvqBrh9NgMXcTOHCQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -9857,6 +9871,7 @@
       "version": "22.19.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -9893,6 +9908,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -9928,6 +9944,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10021,6 +10038,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10610,6 +10628,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -10630,6 +10649,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -10707,6 +10727,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -11236,6 +11257,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -11267,6 +11289,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11310,6 +11333,7 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -11404,6 +11428,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11531,6 +11556,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
@@ -11571,6 +11597,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -12232,6 +12259,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -12264,6 +12292,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -12321,6 +12350,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -12488,6 +12518,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12612,6 +12643,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13688,6 +13720,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -14207,6 +14240,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -14253,6 +14287,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14292,6 +14327,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -14386,6 +14422,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14682,6 +14719,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -14960,6 +14998,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -15019,6 +15058,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -15063,6 +15103,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -15586,6 +15627,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -15610,6 +15652,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
@@ -15705,6 +15748,7 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -15867,7 +15911,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15880,6 +15924,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -15938,6 +15983,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -15954,6 +16000,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -16255,6 +16302,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -16493,6 +16541,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.0"
@@ -18922,6 +18971,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -19067,6 +19117,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "keywords": [],
   "dependencies": {
-    "@electron/remote": "^2.1.3",
     "7zip-bin": "3.1.0",
     "adm-zip": "0.4.13",
     "await-spawn": "4.0.1",

--- a/packages/adapters/electron/src/main.ts
+++ b/packages/adapters/electron/src/main.ts
@@ -10,7 +10,7 @@ import fs from 'fs-extra';
 import { createElectronAdapters } from './adapters/index.js';
 import { createContainer } from '@quiqr/backend';
 import { createServer } from '@quiqr/backend/api';
-import { getCurrentInstanceOrNew, initializeRemoteMain } from './ui-managers/main-window-manager.js';
+import { getCurrentInstanceOrNew } from './ui-managers/main-window-manager.js';
 import { menuManager } from './ui-managers/menu-manager.js';
 
 const isDev = process.env.NODE_ENV === 'development';
@@ -131,9 +131,6 @@ function createWindow(container?: any): BrowserWindow {
  */
 app.on('ready', async () => {
   console.log('Electron app ready!');
-
-  // Initialize @electron/remote
-  initializeRemoteMain();
 
   // Start backend first
   const { windowAdapter, container } = await startBackend();

--- a/packages/adapters/electron/src/ui-managers/log-window-manager.ts
+++ b/packages/adapters/electron/src/ui-managers/log-window-manager.ts
@@ -64,8 +64,8 @@ function createWindow(): BrowserWindow {
     backgroundColor: '#ffffff',
     title: 'Quiqr Console',
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false
+      nodeIntegration: false,
+      contextIsolation: true
     },
     x: logWindowState.x,
     y: logWindowState.y,

--- a/packages/adapters/electron/src/ui-managers/main-window-manager.ts
+++ b/packages/adapters/electron/src/ui-managers/main-window-manager.ts
@@ -3,7 +3,6 @@
  */
 
 import { BrowserWindow } from 'electron';
-import remoteMain from '@electron/remote/main/index.js';
 import windowStateKeeper from 'electron-window-state';
 
 const isDev = process.env.NODE_ENV === 'development';
@@ -40,9 +39,8 @@ function createWindow(): BrowserWindow {
     frame: true,
     backgroundColor: '#ffffff',
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false
-      // Note: enableRemoteModule is deprecated, use @electron/remote instead
+      nodeIntegration: false,
+      contextIsolation: true
     },
     x: mainWindowState.x,
     y: mainWindowState.y,
@@ -54,9 +52,6 @@ function createWindow(): BrowserWindow {
 
   // Let electron-window-state manage window position/size
   mainWindowState.manage(mainWindow);
-
-  // Enable @electron/remote for this window
-  remoteMain.enable(mainWindow.webContents);
 
   // Open DevTools if DEVTOOLS env var is set
   if (process.env.DEVTOOLS) {
@@ -118,12 +113,4 @@ export async function closeSiteAndShowSelectSites(): Promise<boolean> {
   mainWindow.setTitle('Quiqr: Select site');
 
   return true;
-}
-
-/**
- * Initialize remote main module
- * Call this before creating any windows
- */
-export function initializeRemoteMain(): void {
-  remoteMain.initialize();
 }


### PR DESCRIPTION
This PR rewrites bundle file uploads to use the API instead of @electron/remote.
All dependencies on @electron/remote are now fully removed.

This means we can enable recommended security practices by Electron for our BrowserWindows:
```
  mainWindow = new BrowserWindow({
    webPreferences: {
      nodeIntegration: false, 
      contextIsolation: true 
    },
  });
```

More info 
- https://www.electronjs.org/docs/latest/tutorial/context-isolation#what-is-it
- https://www.electronjs.org/docs/latest/tutorial/sandbox