### PR TITLE
fix: add missing check for site name in config

### DIFF
--- a/packages/backend/src/services/configuration/configuration-data-provider.ts
+++ b/packages/backend/src/services/configuration/configuration-data-provider.ts
@@ -112,7 +112,7 @@ export class ConfigurationDataProvider {
         let needsMigration = false;
 
         // Migration: Ensure name field exists - use key as fallback
-        if (result.success) {
+        if (result.success && !result.data.name) {
           result.data.name = result.data.key;
           needsMigration = true;
           this.logger.appendLine(`Migration: Added missing 'name' field to '${conffile}'`);


### PR DESCRIPTION
This PR adds a missing check for the `name` property in `config.json`

When a `config.json` from `~/Quiqr/sites/some-example-site/config.json` gets loaded for the first time, we provide defaults if certain properties are missing. For example: if the `name` property does not exist in the config, we use the site key as the default.