### PR TITLE
main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Next Release
 
+- feature: restore build action buttons on single and collection forms with per-button loading state
+- feature: auto-save before build action execution
+- feature: build action console output panel with stdout/stderr display and truncation
+- feature: file download endpoint for `stdout_type: file_path` build results (path-restricted to site directory)
+- feature: global build action variables in instance settings, overriding YAML defaults
+- feature: Variables section in Preferences UI for managing global build action variables
+- feature: `QUIQR_DATA_DIR` env var to override standalone data directory
+- feature: `HOST` / `BIND_ADDRESS` env var to control server bind address (for reverse proxy setups)
+- feature: `QUIQR_CONFIG_FILE` env var to use an external config file (NixOS/Docker integration)
+- feature: separate `runtime_state.json` for server-managed state (session secret), keeping `instance_settings.json` read-only
+- fix: accept both `buildActions` (camelCase) and `build_actions` (snake_case) in site model YAML
+- fix: global variables not persisted via Preferences UI (`updateInstanceSettings` missing `variables` merge)
+
 ## 0.23.0 (2026-04-07)
 
 - feature: unified frontend serving — standalone server serves both API and frontend from a single Express server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@
 - feature: separate `runtime_state.json` for server-managed state (session secret), keeping `instance_settings.json` read-only
 - fix: accept both `buildActions` (camelCase) and `build_actions` (snake_case) in site model YAML
 - fix: global variables not persisted via Preferences UI (`updateInstanceSettings` missing `variables` merge)
-
-## 0.23.0 (2026-04-07)
-
 - feature: unified frontend serving — standalone server serves both API and frontend from a single Express server
 - feature: JWT-based authentication for standalone mode with local file user provider
 - feature: login page, forced password change on first login, User menu with logout and change password

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+## 0.23.0 (2026-04-07)
+
 - feature: unified frontend serving — standalone server serves both API and frontend from a single Express server
 - feature: JWT-based authentication for standalone mode with local file user provider
 - feature: login page, forced password change on first login, User menu with logout and change password

--- a/openspec/changes/archive/2026-04-24-nixpkgs-standalone-integration/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-24-nixpkgs-standalone-integration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/archive/2026-04-24-nixpkgs-standalone-integration/design.md
+++ b/openspec/changes/archive/2026-04-24-nixpkgs-standalone-integration/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The standalone adapter (`packages/adapters/standalone/src/main.ts`) is the entry point for non-Electron deployments. It creates the DI container, configures auth, and starts the Express server. Currently it hardcodes paths and mixes config with runtime state.
+
+The Express server (`packages/backend/src/api/server.ts`) calls `app.listen(port)` without a host parameter, always binding to all interfaces.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow external control of data directory, bind address, and config file location via environment variables
+- Separate read-only config from server-managed runtime state
+- All changes backwards compatible — no env vars = same behavior as before
+
+**Non-Goals:**
+- Changing the Electron adapter or unified config service internals
+- Adding NixOS-specific code to this repo
+
+## Decisions
+
+### 1. Environment variable naming
+
+| Env var | Purpose | Default |
+|---------|---------|---------|
+| `QUIQR_DATA_DIR` | Data directory (replaces `~/.quiqr-standalone`) | `~/.quiqr-standalone` |
+| `HOST` / `BIND_ADDRESS` | Server bind address | `0.0.0.0` |
+| `QUIQR_CONFIG_FILE` | Path to `instance_settings.json` | `<dataDir>/instance_settings.json` |
+| `PORT` | Server port (already exists) | `5150` |
+
+**Rationale:** `QUIQR_DATA_DIR` is namespaced to avoid collisions. `HOST` and `PORT` follow common conventions (Heroku, Railway, etc.). `BIND_ADDRESS` is a fallback for environments where `HOST` has a different meaning. `QUIQR_CONFIG_FILE` is namespaced since it's Quiqr-specific.
+
+### 2. Bind address: add `host` to `ServerOptions`
+
+Add optional `host?: string` to `ServerOptions` in `server.ts`. Change `app.listen(port)` to `app.listen(port, host)`. When `host` is undefined, Express defaults to `0.0.0.0` (no behavior change).
+
+**Reference:** `packages/backend/src/api/server.ts` lines 31-55 (`ServerOptions`) and 369-384 (`startServer`).
+
+### 3. Runtime state separation
+
+Create a new file `runtime_state.json` in `userDataPath` for server-managed mutable state. Currently the only item is `auth.session.secret`.
+
+On startup:
+1. Read config from `instance_settings.json` (or `QUIQR_CONFIG_FILE`)
+2. Read runtime state from `runtime_state.json` in `userDataPath`
+3. If session secret is in runtime state, use it. Otherwise generate one and write to runtime state.
+4. Never write to `instance_settings.json`
+
+This change is localized to `main.ts` — the session secret logic (lines 95-112) already reads/writes directly, bypassing the unified config service. We just redirect the writes to `runtime_state.json`.
+
+### 4. Config file override via `QUIQR_CONFIG_FILE`
+
+When `QUIQR_CONFIG_FILE` is set, copy it to the data directory as `instance_settings.json` on startup (or symlink). This way the unified config service still reads from its expected location, but the source is externally managed.
+
+**Alternative considered:** Teaching unified config service about external config paths — rejected because it would require changes across the config stack. Simply making the external file available at the expected location is simpler.
+
+**Simpler alternative:** Just pass `QUIQR_CONFIG_FILE` path to the container creation so the config service reads from there. Let me check if `createContainer` supports this... The `createContainer` takes `userDataPath` and the config store reads from that directory. The simplest approach: if `QUIQR_CONFIG_FILE` is set, copy/symlink it into `userDataPath/instance_settings.json` before creating the container.
+
+## Risks / Trade-offs
+
+**Risk: QUIQR_CONFIG_FILE gets stale if source changes while server is running**
+Mitigation: Copy happens on startup only. NixOS restarts the service on config change, so this is fine.
+
+**Risk: runtime_state.json permissions**
+Mitigation: The server creates it in `userDataPath` which it already has write access to. Same permissions as before.

--- a/openspec/changes/archive/2026-04-24-nixpkgs-standalone-integration/proposal.md
+++ b/openspec/changes/archive/2026-04-24-nixpkgs-standalone-integration/proposal.md
@@ -1,0 +1,30 @@
+# NixOS/nixpkgs Standalone Adapter Integration
+
+## Summary
+
+Three changes to the standalone adapter to integrate cleanly with NixOS packaging, Docker/Kubernetes, and any externally-managed deployment. All changes are backwards compatible.
+
+## Motivation
+
+The NixOS module (`quiqr-server.nix`) runs quiqr-server as a systemd service with an optional nginx reverse proxy. Three issues prevent clean integration:
+
+1. **Data directory is hardcoded** to `~/.quiqr-standalone` — NixOS services run as dedicated users and need to control the data path via environment variable, not by hacking `HOME`.
+
+2. **No bind address control** — the server always binds to `0.0.0.0`. Behind nginx, it should bind to `127.0.0.1` only. No env var exists for this.
+
+3. **Config and runtime state are mixed** — `instance_settings.json` is both read (config) and written (auto-generated session secret). NixOS generates config declaratively on each service start, which conflicts with server-written state in the same file.
+
+## Scope
+
+### In scope
+
+1. `QUIQR_DATA_DIR` env var to override the default data directory
+2. `HOST` / `BIND_ADDRESS` env var for server bind address, passed through `startServer()`
+3. Separate `runtime_state.json` for server-managed state (session secret), keeping `instance_settings.json` as read-only config
+4. Optional `QUIQR_CONFIG_FILE` env var to point to an external config file
+
+### Out of scope
+
+- NixOS module itself (lives in nixpkgs, not this repo)
+- Changes to Electron adapter
+- Changes to the unified config service internals (only standalone adapter and server.ts)

--- a/openspec/changes/archive/2026-04-24-nixpkgs-standalone-integration/specs/adapters/spec.md
+++ b/openspec/changes/archive/2026-04-24-nixpkgs-standalone-integration/specs/adapters/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: QUIQR_DATA_DIR environment variable
+
+The standalone adapter SHALL support a `QUIQR_DATA_DIR` environment variable that overrides the default data directory (`~/.quiqr-standalone`).
+
+#### Scenario: QUIQR_DATA_DIR is set
+- **WHEN** the `QUIQR_DATA_DIR` environment variable is set to `/var/lib/quiqr`
+- **THEN** the server SHALL use `/var/lib/quiqr` as the `userDataPath`
+- **AND** all data files (config, logs, sites, runtime state) SHALL be stored under that directory
+
+#### Scenario: QUIQR_DATA_DIR is not set
+- **WHEN** the `QUIQR_DATA_DIR` environment variable is not set
+- **THEN** the server SHALL default to `~/.quiqr-standalone` (unchanged behavior)
+
+### Requirement: HOST / BIND_ADDRESS environment variable
+
+The standalone adapter SHALL support `HOST` and `BIND_ADDRESS` environment variables to control the server bind address. `HOST` SHALL take precedence over `BIND_ADDRESS`.
+
+#### Scenario: HOST is set
+- **WHEN** the `HOST` environment variable is set to `127.0.0.1`
+- **THEN** the server SHALL bind to `127.0.0.1` only
+- **AND** the server SHALL NOT be accessible from other network interfaces
+
+#### Scenario: BIND_ADDRESS is set (HOST not set)
+- **WHEN** `HOST` is not set and `BIND_ADDRESS` is set to `127.0.0.1`
+- **THEN** the server SHALL bind to `127.0.0.1`
+
+#### Scenario: Neither HOST nor BIND_ADDRESS is set
+- **WHEN** neither environment variable is set
+- **THEN** the server SHALL bind to `0.0.0.0` (all interfaces, unchanged behavior)
+
+### Requirement: Server bind address in ServerOptions
+
+`ServerOptions` in `server.ts` SHALL accept an optional `host` parameter. `startServer()` SHALL pass it to `app.listen(port, host)`.
+
+#### Scenario: host provided in ServerOptions
+- **WHEN** `startServer()` is called with `{ host: '127.0.0.1', port: 5150 }`
+- **THEN** Express SHALL listen on `127.0.0.1:5150`
+
+#### Scenario: host not provided in ServerOptions
+- **WHEN** `startServer()` is called without a `host` option
+- **THEN** Express SHALL listen on all interfaces (Express default behavior)
+
+### Requirement: Separate runtime state from config
+
+The standalone adapter SHALL separate server-managed runtime state from read-only configuration by using a dedicated `runtime_state.json` file in the data directory.
+
+#### Scenario: Session secret auto-generation
+- **WHEN** the server starts and no session secret exists in `runtime_state.json`
+- **THEN** the server SHALL generate a random session secret
+- **AND** persist it to `runtime_state.json` (NOT `instance_settings.json`)
+
+#### Scenario: Session secret persistence across restarts
+- **WHEN** the server restarts and `runtime_state.json` contains a session secret
+- **THEN** the server SHALL reuse the persisted secret
+- **AND** existing user sessions SHALL remain valid
+
+#### Scenario: External config not overwritten
+- **WHEN** the server starts with a NixOS-managed `instance_settings.json`
+- **THEN** the server SHALL NOT write to `instance_settings.json`
+- **AND** only `runtime_state.json` SHALL be written by the server
+
+### Requirement: QUIQR_CONFIG_FILE environment variable
+
+The standalone adapter SHALL support a `QUIQR_CONFIG_FILE` environment variable to specify an external config file path.
+
+#### Scenario: QUIQR_CONFIG_FILE is set
+- **WHEN** `QUIQR_CONFIG_FILE` is set to `/etc/quiqr/instance_settings.json`
+- **THEN** the server SHALL copy that file to `<userDataPath>/instance_settings.json` on startup
+- **AND** the unified config service SHALL read from the copied file
+
+#### Scenario: QUIQR_CONFIG_FILE is not set
+- **WHEN** `QUIQR_CONFIG_FILE` is not set
+- **THEN** the server SHALL read config from `<userDataPath>/instance_settings.json` (unchanged behavior)

--- a/openspec/changes/archive/2026-04-24-nixpkgs-standalone-integration/tasks.md
+++ b/openspec/changes/archive/2026-04-24-nixpkgs-standalone-integration/tasks.md
@@ -1,0 +1,26 @@
+## 1. QUIQR_DATA_DIR environment variable
+
+- [x] 1.1 In `packages/adapters/standalone/src/main.ts`, change `userDataPath` to read from `process.env.QUIQR_DATA_DIR` with fallback to `join(homedir(), '.quiqr-standalone')`
+
+## 2. HOST / BIND_ADDRESS environment variable
+
+- [x] 2.1 Add optional `host?: string` to `ServerOptions` in `packages/backend/src/api/server.ts`
+- [x] 2.2 Change `app.listen(port)` to `app.listen(port, host)` in `startServer()`, include host in the log output
+- [x] 2.3 In `packages/adapters/standalone/src/main.ts`, read `HOST` / `BIND_ADDRESS` from env and pass `host` to `startServer()`
+
+## 3. Separate runtime state from config
+
+- [x] 3.1 In `main.ts`, change the session secret logic to read/write `runtime_state.json` instead of `instance_settings.json`
+- [x] 3.2 On startup, if `runtime_state.json` has a session secret, use it. Otherwise generate and persist to `runtime_state.json`.
+- [x] 3.3 Remove the code that writes session secret back to `instance_settings.json`
+
+## 4. QUIQR_CONFIG_FILE environment variable
+
+- [x] 4.1 In `main.ts`, if `QUIQR_CONFIG_FILE` is set, copy the file to `<userDataPath>/instance_settings.json` before creating the container
+- [x] 4.2 Ensure the data directory exists before copying (use `mkdirSync` with `recursive: true`)
+
+## 5. Verification
+
+- [x] 5.1 Verify TypeScript compiles cleanly (`npx tsc --noEmit` for backend and standalone adapter)
+- [x] 5.2 Run all backend tests to verify no regressions
+- [x] 5.3 Test standalone startup with default env (no env vars set) — verify unchanged behavior

--- a/openspec/changes/archive/2026-04-24-restore-build-actions/design.md
+++ b/openspec/changes/archive/2026-04-24-restore-build-actions/design.md
@@ -1,0 +1,122 @@
+## Context
+
+Build actions allow site developers to define custom commands (Quarto render, Pandoc export, etc.) in their model YAML. These commands execute on the backend and return results to the frontend. The feature was fully functional in v0.19.x but the UI layer was lost during the v0.21–v0.22 rewrite.
+
+The backend stack is complete and unchanged:
+- `BuildActionService` handles command execution with platform detection, variable substitution, and path replacements
+- `WorkspaceService.buildSingle()` and `buildCollectionItem()` find the action config and delegate to `BuildActionService`
+- API handlers and frontend API client methods exist and are wired
+
+The gap is:
+1. `SukohForm` accepts `buildActions` prop but never renders buttons
+2. `Single.tsx` and `CollectionItem.tsx` never pass `onDocBuild` callback
+3. No mechanism to download files when `stdout_type: "file_path"`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore build action buttons in the form toolbar (top-right, alongside PAGE ASSIST)
+- Auto-save before executing a build action
+- Show per-button loading state during execution
+- Display build output in a collapsible console panel and snackbar notifications
+- Serve generated files for download when `stdout_type: "file_path"`, restricted to site directory
+
+**Non-Goals:**
+- Streaming build output via SSE (future: readonly terminal UI)
+- Changes to the build action schema or backend execution logic
+- Support for downloading files outside the site directory
+
+## Decisions
+
+### 1. Button placement: top-right action bar alongside PAGE ASSIST
+
+Build action buttons render in the same position area as the PAGE ASSIST button (top-right of form). Each `BuildAction` gets its own `LoadingButton`.
+
+**Rationale:** Build actions and AI assist are both document-level operations. Grouping them creates a consistent action bar. The save FAB stays at bottom-right as the primary action.
+
+**Alternative considered:** Bottom toolbar next to save FAB — rejected because it crowds the fixed-position area and mixes save (always-present) with contextual actions.
+
+### 2. MUI LoadingButton for per-action loading state
+
+Use `@mui/lab/LoadingButton` with a `Set<string>` tracking which action keys are currently running.
+
+**Rationale:** Each action runs independently and may take different amounts of time. Users need to see which specific action is running. `LoadingButton` provides this out of the box with no custom spinner logic.
+
+### 3. Auto-save before build
+
+When a build action button is clicked, the form auto-saves first (if dirty), then executes the build action. This ensures the build operates on the latest content.
+
+**Rationale:** Build actions operate on the saved file on disk. Running a build on stale content would produce confusing results. The old implementation also saved before building.
+
+**Flow:**
+```
+User clicks build → saveContent() → await save complete → api.buildSingle/buildCollectionItem() → handle result
+```
+
+### 4. File download via path-restricted endpoint
+
+New endpoint: `GET /api/sites/:siteKey/workspaces/:workspaceKey/file-download?path=<relative-or-absolute-path>`
+
+Security:
+1. Resolve the path with `fs.realpath()` to eliminate symlinks and `..` sequences
+2. Look up the workspace's site root directory via `WorkspaceService`
+3. Verify `resolvedPath.startsWith(siteRoot)` — reject with 403 if false
+4. Stream file with `Content-Disposition: attachment; filename="<basename>"`
+
+**Rationale:** The old Electron code used `shell.openPath()` which doesn't work in standalone mode. A download endpoint works in both runtimes. Path restriction to the site directory prevents path traversal attacks from malicious model YAML or crafted build output.
+
+**Alternative considered:** Signed token approach — more flexible but adds unnecessary complexity for this use case. Build outputs should always be within the site directory.
+
+### 5. Console output panel: simple collapsible pre block
+
+A `BuildActionOutput` component renders below the form fields when build output is available. It shows:
+- Action name and status (success/error)
+- Stdout content in a `<pre>` block
+- Stderr content (if any) in a visually distinct error block
+- Dismiss button to collapse
+
+State is local to `SukohForm` — no global state needed since output is per-form.
+
+**Rationale:** Keep it simple for now. The future "GitHub Actions style terminal" proposal will replace this with a proper terminal component that can also show Hugo build output, git sync output, etc.
+
+### 6. Communication pattern follows existing architecture
+
+```
+SukohForm (button click)
+    │
+    ▼
+onDocBuild callback (in Single.tsx / CollectionItem.tsx)
+    │
+    ▼
+api.buildSingle() / api.buildCollectionItem()  (packages/frontend/src/api.ts)
+    │
+    ▼
+main-process-bridge HTTP POST
+    │
+    ▼
+Express handler → WorkspaceService → BuildActionService
+    │
+    ▼
+spawn() → collect stdout/stderr → return BuildActionResult
+    │
+    ▼
+Frontend handles result:
+  - stdout_type === "file_path" → trigger download via file-download endpoint
+  - otherwise → show in console panel + snackbar
+```
+
+No new patterns introduced. The file-download endpoint is the only new backend route.
+
+## Risks / Trade-offs
+
+**Risk: Build action hangs indefinitely**
+The current `BuildActionService` has no timeout. A command that never exits will leave the button in loading state forever.
+Mitigation: Out of scope for this change. Document as a known limitation. A future change can add configurable timeouts.
+
+**Risk: Large stdout output**
+A build action that produces megabytes of stdout could cause memory issues in the console panel.
+Mitigation: Truncate displayed output to last 500 lines in `BuildActionOutput`. Full output is still in backend logs.
+
+**Risk: File download path validation race condition**
+Between `realpath` check and file read, the file could be replaced with a symlink.
+Mitigation: Use `O_NOFOLLOW` flag when opening the file, or re-check after open. Low risk in practice since the attacker would need filesystem access to the site directory.

--- a/openspec/changes/archive/2026-04-24-restore-build-actions/proposal.md
+++ b/openspec/changes/archive/2026-04-24-restore-build-actions/proposal.md
@@ -1,0 +1,99 @@
+# Restore Build Actions
+
+## Summary
+
+Build actions — custom commands (e.g., Quarto render, Pandoc export) triggered from the form toolbar — were lost during the big rewrite. The entire backend stack (type schemas, execution service, API handlers, frontend API client) is intact. The gap is purely in the frontend UI: `SukohForm` accepts a `buildActions` prop but never renders buttons or wires the `onDocBuild` callback.
+
+This change restores the build actions UI and adds a safe file download endpoint for `stdout_type: "file_path"` results.
+
+## Motivation
+
+Build actions were a key feature for users with Quarto, Pandoc, or custom build workflows. The CHANGELOG (v0.19.0–v0.19.7) documents:
+- Build action buttons on single and collection forms
+- Loading spinners during execution
+- `stdout_type: "file_path"` to open generated files
+- `site_path_replace` / `document_path_replace` for WSL path mapping
+- Custom variables in build action definitions
+- Timeout prevention for long-running actions
+
+All of this backend logic still works. Only the UI trigger is missing.
+
+## Scope
+
+### In scope
+1. Render build action buttons in `SukohForm` next to the PAGE ASSIST button
+2. Wire `onDocBuild` callback in `Single.tsx` and `CollectionItem.tsx`
+3. Auto-save document before executing a build action
+4. Per-button loading state using MUI `LoadingButton`
+5. Show build results: snackbar for success/error, console output panel for stdout/stderr
+6. New backend endpoint for safe file download (for `stdout_type: "file_path"`)
+7. File download restricted to site directory with `realpath` validation to prevent path traversal
+
+### Out of scope
+- Readonly terminal UI (GitHub Actions style) — future proposal
+- Streaming build output via SSE — future proposal
+- New build action types or schema changes
+
+## What exists (no changes needed)
+
+| Layer | Status | Location |
+|-------|--------|----------|
+| Zod schemas | Complete | `packages/types/src/schemas/config.ts` (lines 11-46) |
+| API response schema | Complete | `packages/types/src/schemas/api.ts` (lines 129-134) |
+| BuildActionService | Complete | `packages/backend/src/build-actions/build-action-service.ts` |
+| WorkspaceService integration | Complete | `packages/backend/src/services/workspace/workspace-service.ts` |
+| API handlers | Complete | `single-handlers.ts`, `collection-handlers.ts` |
+| Frontend API client | Complete | `packages/frontend/src/api.ts` (`buildSingle`, `buildCollectionItem`) |
+| Container props | Complete | `Single.tsx` and `CollectionItem.tsx` pass `buildActions` to `SukohForm` |
+
+## What needs to change
+
+### 1. SukohForm — render build action buttons
+**File:** `packages/frontend/src/components/SukohForm/index.tsx`
+
+- Destructure `buildActions` and `onDocBuild` from props (currently ignored)
+- For each build action, render a `LoadingButton` (from `@mui/lab`) positioned next to the PAGE ASSIST button
+- Use `button_text` (or fall back to `title`, then `key`) as button label
+- Track per-button loading state with a `Set<string>` of running action keys
+- On click: auto-save, then call `onDocBuild(buildAction)`
+
+### 2. Single.tsx — wire onDocBuild
+**File:** `packages/frontend/src/containers/WorkspaceMounted/Single.tsx`
+
+- Add `handleDocBuild` callback that calls `api.buildSingle(siteKey, workspaceKey, singleKey, buildAction.key)`
+- Pass as `onDocBuild` prop to `SukohForm`
+- Handle result: snackbar on success, snackbar on error
+- If `stdout_type === "file_path"`: trigger file download via new endpoint
+
+### 3. CollectionItem.tsx — wire onDocBuild
+**File:** `packages/frontend/src/containers/WorkspaceMounted/Collection/CollectionItem.tsx`
+
+- Same pattern as Single.tsx but calls `api.buildCollectionItem()`
+
+### 4. File download endpoint (new)
+**File:** `packages/backend/src/api/handlers/file-handlers.ts` (new or existing)
+
+- `GET /api/sites/:siteKey/workspaces/:workspaceKey/file-download?path=<path>`
+- Resolve the requested path with `fs.realpath()`
+- Verify the resolved path is under the workspace's site root directory
+- Reject with 403 if path is outside the site directory (prevents path traversal)
+- Stream the file with `Content-Disposition: attachment`
+
+### 5. Console output panel
+**File:** `packages/frontend/src/components/SukohForm/BuildActionOutput.tsx` (new)
+
+- Collapsible panel below the form showing stdout/stderr from the most recent build action
+- Simple `<pre>` block, auto-scrolls to bottom
+- Dismissible
+
+## Security
+
+The file download endpoint must guard against path traversal:
+- Use `fs.realpath()` to resolve symlinks and `..` sequences
+- Compare resolved path against the workspace's site root
+- Reject any path outside the site directory with HTTP 403
+- This prevents malicious model YAML or crafted build output from exfiltrating arbitrary files
+
+## Risk
+
+Low — this is a restoration, not a new feature. The backend is battle-tested and unchanged. The frontend work is straightforward button rendering and API calls.

--- a/openspec/changes/archive/2026-04-24-restore-build-actions/specs/communication-layer/spec.md
+++ b/openspec/changes/archive/2026-04-24-restore-build-actions/specs/communication-layer/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: File download endpoint with path restriction
+
+The backend SHALL expose a file download endpoint that streams a file from the workspace's site directory, with path traversal protection.
+
+#### Scenario: Valid file download within site directory
+- **WHEN** a GET request is made to `/api/sites/:siteKey/workspaces/:workspaceKey/file-download` with a `path` query parameter
+- **AND** the resolved path is within the workspace's site root directory
+- **THEN** the server SHALL stream the file with `Content-Disposition: attachment; filename="<basename>"`
+- **AND** the response SHALL include an appropriate `Content-Type` header
+
+#### Scenario: Path traversal attempt
+- **WHEN** a GET request is made to the file-download endpoint
+- **AND** the resolved path (after `fs.realpath()`) is outside the workspace's site root directory
+- **THEN** the server SHALL respond with HTTP 403 Forbidden
+- **AND** the response SHALL NOT reveal the resolved path
+
+#### Scenario: File does not exist
+- **WHEN** a GET request is made to the file-download endpoint
+- **AND** the specified file does not exist
+- **THEN** the server SHALL respond with HTTP 404 Not Found
+
+#### Scenario: Path with symlinks
+- **WHEN** the requested path contains symlinks
+- **THEN** the server SHALL resolve the full real path before checking it is within the site directory
+- **AND** if the resolved path is outside the site directory, the server SHALL respond with HTTP 403
+
+#### Scenario: Authentication required
+- **WHEN** a GET request is made to the file-download endpoint
+- **AND** the request is in standalone mode with authentication enabled
+- **THEN** the endpoint SHALL require valid authentication (JWT token)
+- **AND** unauthenticated requests SHALL receive HTTP 401

--- a/openspec/changes/archive/2026-04-24-restore-build-actions/specs/frontend-components/spec.md
+++ b/openspec/changes/archive/2026-04-24-restore-build-actions/specs/frontend-components/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Build action buttons in SukohForm
+
+SukohForm SHALL render a `LoadingButton` for each entry in the `buildActions` prop. Buttons SHALL be positioned in the top-right action bar alongside the PAGE ASSIST button. The button label SHALL use `button_text`, falling back to `title`, then `key`.
+
+#### Scenario: Build actions defined in model
+- **WHEN** a single or collection has `build_actions` defined in its model config
+- **THEN** SukohForm SHALL render one `LoadingButton` per build action in the top-right area
+- **AND** each button SHALL display the action's `button_text` (or `title`, or `key` as fallback)
+
+#### Scenario: No build actions defined
+- **WHEN** a single or collection has no `build_actions` or an empty array
+- **THEN** SukohForm SHALL not render any build action buttons
+- **AND** the PAGE ASSIST button (if present) SHALL remain unaffected
+
+#### Scenario: Build action button clicked
+- **WHEN** user clicks a build action button
+- **THEN** the system SHALL auto-save the form if there are unsaved changes
+- **AND** after save completes, the system SHALL call the `onDocBuild` callback with the `BuildAction` object
+- **AND** the clicked button SHALL show a loading spinner until the build completes
+
+#### Scenario: Multiple build actions
+- **WHEN** multiple build actions are defined
+- **THEN** each SHALL have its own independent loading state
+- **AND** clicking one button SHALL NOT disable or affect other build action buttons
+
+### Requirement: Build action result handling in Single and CollectionItem containers
+
+`Single.tsx` and `CollectionItem.tsx` SHALL pass an `onDocBuild` handler to `SukohForm` that calls `api.buildSingle()` or `api.buildCollectionItem()` respectively, and handles the result.
+
+#### Scenario: Successful build action on a single
+- **WHEN** a build action completes successfully on a single
+- **THEN** the container SHALL show a success snackbar with the action name
+- **AND** the build output SHALL be available in the console output panel
+
+#### Scenario: Successful build action on a collection item
+- **WHEN** a build action completes successfully on a collection item
+- **THEN** the container SHALL show a success snackbar with the action name
+- **AND** the build output SHALL be available in the console output panel
+
+#### Scenario: Build action returns file_path stdout type
+- **WHEN** a build action completes with `stdout_type === "file_path"`
+- **THEN** the system SHALL trigger a file download via the file-download endpoint
+- **AND** the file path from stdout SHALL be passed to the download endpoint
+
+#### Scenario: Build action fails
+- **WHEN** a build action fails (non-zero exit code or error)
+- **THEN** the container SHALL show an error snackbar with the action name and error message
+- **AND** any stderr output SHALL be displayed in the console output panel
+
+### Requirement: Build action console output panel
+
+SukohForm SHALL include a collapsible `BuildActionOutput` component that displays stdout and stderr from the most recent build action execution.
+
+#### Scenario: Build action produces output
+- **WHEN** a build action completes (success or error)
+- **AND** there is stdout or stderr content
+- **THEN** the console output panel SHALL appear below the form fields
+- **AND** stdout SHALL be displayed in a monospace `<pre>` block
+- **AND** stderr SHALL be visually distinct (e.g., red text or separate section)
+
+#### Scenario: Dismiss console output
+- **WHEN** the user clicks the dismiss/close button on the console output panel
+- **THEN** the panel SHALL collapse and hide
+
+#### Scenario: Large output truncation
+- **WHEN** build output exceeds 500 lines
+- **THEN** the panel SHALL display only the last 500 lines
+- **AND** a message SHALL indicate that output was truncated
+
+#### Scenario: New build action replaces previous output
+- **WHEN** a new build action is executed while previous output is displayed
+- **THEN** the previous output SHALL be replaced with the new output

--- a/openspec/changes/archive/2026-04-24-restore-build-actions/tasks.md
+++ b/openspec/changes/archive/2026-04-24-restore-build-actions/tasks.md
@@ -1,0 +1,44 @@
+## 1. Backend: File download endpoint
+
+- [x] 1.1 Add file-download handler in `packages/backend/src/api/handlers/file-download-handler.ts` — accepts `path` query param, resolves with `fs.realpath()`, validates path is under site root, streams file with `Content-Disposition: attachment`
+- [x] 1.2 Register the file-download route in `packages/backend/src/api/server.ts` under `GET /api/sites/:siteKey/workspaces/:workspaceKey/file-download`
+- [x] 1.3 Add `fileDownload` method to `packages/frontend/src/api.ts` that constructs the download URL and triggers a browser download (e.g., `window.open` or hidden anchor click)
+- [x] 1.4 Write tests for path traversal rejection (symlinks, `..` sequences, absolute paths outside site root)
+
+## 2. Frontend: SukohForm build action buttons
+
+- [x] 2.1 Destructure `buildActions` and `onDocBuild` from props in `SukohForm/index.tsx`
+- [x] 2.2 Render `LoadingButton` (from `@mui/lab`) for each build action in the top-right area next to PAGE ASSIST button, using `button_text` / `title` / `key` as label
+- [x] 2.3 Add `loadingActions` state (`Set<string>`) to track per-button loading, set loading on click, clear on result/error
+
+## 3. Frontend: Auto-save before build
+
+- [x] 3.1 In the build action click handler inside `SukohForm`, call `saveContent()` first if form is dirty, then invoke `onDocBuild` after save completes
+
+## 4. Frontend: Wire onDocBuild in containers
+
+- [x] 4.1 Add `handleDocBuild` callback in `Single.tsx` that calls `api.buildSingle(siteKey, workspaceKey, singleKey, buildAction.key)` and returns the result
+- [x] 4.2 Add `handleDocBuild` callback in `CollectionItem.tsx` that calls `api.buildCollectionItem(siteKey, workspaceKey, collectionKey, collectionItemKey, buildAction.key)` and returns the result
+- [x] 4.3 Pass `onDocBuild` prop to `SukohForm` in both containers
+
+## 5. Frontend: Result handling
+
+- [x] 5.1 On build success: show success snackbar with action name
+- [x] 5.2 On build error: show error snackbar with action name and error message
+- [x] 5.3 On `stdout_type === "file_path"`: trigger file download using the `fileDownload` API method from task 1.3
+- [x] 5.4 Pass stdout/stderr content back to `SukohForm` for console output display
+
+## 6. Frontend: Build action console output panel
+
+- [x] 6.1 Create `BuildActionOutput` component in `packages/frontend/src/components/SukohForm/BuildActionOutput.tsx` — collapsible panel with monospace `<pre>` block, stderr in distinct style, dismiss button
+- [x] 6.2 Add output truncation to last 500 lines with truncation message
+- [x] 6.3 Add `buildOutput` state to `SukohForm` to hold the latest build result, render `BuildActionOutput` below form fields when output is present
+- [x] 6.4 Replace previous output when a new build action is executed
+
+## 7. Verification
+
+- [ ] 7.1 Test with a site model that defines `build_actions` on a single — verify buttons appear, click triggers execution, output shows
+- [ ] 7.2 Test with a collection item that defines `build_actions` — same verification
+- [ ] 7.3 Test `stdout_type: "file_path"` — verify file download triggers and path restriction works
+- [x] 7.4 Test with no `build_actions` defined — verify no buttons appear, no regressions
+- [x] 7.5 Verify TypeScript compiles cleanly (`npx tsc --noEmit` in frontend package)

--- a/openspec/changes/archive/2026-04-24-restore-global-build-variables/design.md
+++ b/openspec/changes/archive/2026-04-24-restore-global-build-variables/design.md
@@ -1,0 +1,75 @@
+## Context
+
+Build actions support `%VARIABLE_NAME` substitution in commands and arguments. Currently, `BuildActionService.replacePathVars()` only uses variables defined per-action in the model YAML (`execute.variables`). The old Quiqr stored global variable overrides in `prefs.variables` which took precedence over YAML defaults — this allowed different machines to use different executable paths without modifying shared model files.
+
+The unified config architecture already has `instanceSettingsSchema` (stored in `instance_settings.json`) which is the correct home for machine-specific settings. Variables fit naturally alongside `storage`, `git`, and `hugo` settings.
+
+Reference implementations:
+- `PrefsHugo.tsx` — existing instance settings UI with toggle switches
+- `PrefsGit.tsx` — existing instance settings UI with text input
+- `BuildActionService.replacePathVars()` — existing variable replacement logic
+
+## Goals / Non-Goals
+
+**Goals:**
+- Store global build action variables in `instance_settings.json` under a `variables` key
+- Merge global variables with per-action YAML variables, with global overrides winning
+- Provide a Preferences UI section for managing global variables (CRUD on key-value pairs)
+- Work identically in both Electron and standalone modes
+
+**Non-Goals:**
+- Environment variable overrides (`QUIQR_VAR_*`) — future enhancement
+- Per-site variable overrides in site settings — future enhancement
+- Changing the `%VAR` replacement syntax
+- Migration from old `prefs.variables` format (the old config format is gone)
+
+## Decisions
+
+### 1. Store variables in instance settings, not user preferences
+
+Variables go in `instanceSettingsSchema` as `variables: z.record(z.string(), z.string()).default({})`.
+
+**Rationale:** Variables are machine-specific (executable paths differ per machine), not user-specific. In standalone multi-user mode, all users on the same machine should share the same `NIX_EXEC` path. Instance settings is the right layer.
+
+**Alternative considered:** User preferences — rejected because executable paths are a property of the machine, not the user's preference.
+
+### 2. Merge strategy: global overrides YAML defaults
+
+When resolving variables for a build action:
+1. Start with YAML-defined variables (`execute.variables`) as the base
+2. Overlay global variables from instance settings
+3. Global wins when both define the same variable name
+
+```
+YAML:    NIX_EXEC=/usr/bin/nix     (default)
+Global:  NIX_EXEC=/run/current/.../nix  (override)
+Result:  NIX_EXEC=/run/current/.../nix  (global wins)
+```
+
+**Rationale:** The YAML provides sensible defaults for the model. The global override is the user's machine-specific correction. This matches the old behavior.
+
+### 3. Pass global variables through WorkspaceService, not directly to BuildActionService
+
+`WorkspaceService.buildSingle()` and `buildCollectionItem()` already call `BuildActionService.runAction()`. They will read global variables from the unified config and pass them as a new parameter.
+
+**Rationale:** Keeps `BuildActionService` decoupled from config — it receives variables, doesn't fetch them. The `WorkspaceService` already has access to the unified config via its dependencies.
+
+### 4. Preferences UI: simple key-value table with add/remove
+
+A new `PrefsVariables.tsx` component renders a table of variable name-value pairs with:
+- Text fields for name and value
+- Add button to append a new row
+- Delete button per row
+- Save persists all variables at once via `updateInstanceSettings`
+
+**Rationale:** Matches the existing Preferences pattern. Variables are simple key-value pairs — no need for complex forms. Reference: `PrefsGit.tsx` for the instance settings save pattern.
+
+## Risks / Trade-offs
+
+**Risk: Variable name collisions with built-in variables**
+Users could define `SITE_PATH` or `DOCUMENT_PATH` as a global variable, overriding built-in path variables.
+Mitigation: Built-in variables (`%SITE_PATH`, `%DOCUMENT_PATH`) are replaced first in `replacePathVars()`, before custom variables. This order is already correct and prevents collisions.
+
+**Risk: Stale variables after instance settings change**
+If a user changes a global variable while a workspace is mounted, the next build action will pick up the new value immediately since `WorkspaceService` reads from the config on each build.
+Mitigation: Not an issue — reading on each build is the correct behavior.

--- a/openspec/changes/archive/2026-04-24-restore-global-build-variables/proposal.md
+++ b/openspec/changes/archive/2026-04-24-restore-global-build-variables/proposal.md
@@ -1,0 +1,87 @@
+# Restore Global Build Action Variables
+
+## Summary
+
+Build actions support per-action default variables defined in the model YAML (`execute.variables`). The old Quiqr also had a **global variable override** mechanism: users could define variables in Preferences (stored in `prefs.variables`) that would override the YAML defaults. This allowed different machines to configure different executable paths (e.g., `NIX_EXEC=/run/current-system/sw/bin/nix` on NixOS vs `/usr/bin/nix` on Ubuntu) without modifying the site model.
+
+This functionality was lost in the rewrite. The `BuildActionService.replacePathVars()` only uses YAML-defined defaults — it has no access to global overrides.
+
+## Motivation
+
+Real-world example from the `msa-packaging` site model:
+
+```yaml
+buildActions:
+  - key: magic_make_pdf
+    button_text: Build PDF
+    execute:
+      variables:
+        - name: "NIX_EXEC"
+          value: /usr/bin/nix
+      unix:
+        command: '%NIX_EXEC'
+        args: ['run', 'github:...#quarto-for-quiqr', '--', '%DOCUMENT_PATH']
+```
+
+The YAML defines `NIX_EXEC=/usr/bin/nix` as a default. But on a NixOS machine, nix lives at `/run/current-system/sw/bin/nix`. Without global overrides, the user must either:
+- Edit the shared model YAML (breaks it for other users)
+- Or not use build actions at all
+
+The old system solved this: define `NIX_EXEC` in Preferences with the machine-specific value. The global value takes precedence over the YAML default.
+
+## Scope
+
+### In scope
+
+1. Add `variables` field to `instanceSettingsSchema` — a key-value map of global build action variables
+2. Wire `BuildActionService` to read global variables from instance settings via the DI container
+3. Merge logic: global variables override YAML defaults (global wins when both define the same name)
+4. Add a Variables section to the Preferences UI for managing global variables (add, edit, remove)
+5. Support the `%VARIABLE_NAME` replacement syntax (existing in `replacePathVars`)
+
+### Out of scope
+
+- Environment variable overrides (e.g., `QUIQR_VAR_NIX_EXEC`) — future enhancement
+- Per-site variable overrides in site settings — future enhancement
+- Changing the replacement syntax (`%VAR` stays, no `{{VAR}}` migration)
+
+## What exists
+
+| Component | Status |
+|-----------|--------|
+| `BuildActionService.replacePathVars()` | Works — replaces `%VAR` with values from `execute.variables` |
+| `instanceSettingsSchema` | Has no `variables` field |
+| Preferences UI | Has no Variables section |
+| Documentation | `packages/docs/docs/configuration/variables.md` exists and describes the old system |
+
+## What needs to change
+
+### 1. Schema: add `variables` to instance settings
+**File:** `packages/types/src/schemas/config.ts`
+
+Add to `instanceSettingsSchema`:
+```typescript
+variables: z.record(z.string(), z.string()).default({})
+```
+
+### 2. Backend: pass global variables to BuildActionService
+**File:** `packages/backend/src/build-actions/build-action-service.ts`
+
+- Add a `globalVariables` parameter to `runAction()` (or read from container)
+- In `replacePathVars()`, merge global variables with per-action variables, with global taking precedence
+
+**File:** `packages/backend/src/services/workspace/workspace-service.ts`
+
+- Read global variables from unified config (`container.unifiedConfig.getInstanceSetting('variables')`)
+- Pass to `BuildActionService.runAction()`
+
+### 3. Frontend: Variables preferences UI
+**File:** `packages/frontend/src/containers/Prefs/PrefsVariables.tsx` (new)
+
+- Table showing variable name + value pairs
+- Add, edit, and remove variables
+- Saves to `instance_settings.json` via `updateInstanceSettings` API
+
+**File:** `packages/frontend/src/containers/Prefs/index.tsx` (or equivalent routing)
+
+- Add Variables tab/section to preferences navigation

--- a/openspec/changes/archive/2026-04-24-restore-global-build-variables/specs/application-settings-ui/spec.md
+++ b/openspec/changes/archive/2026-04-24-restore-global-build-variables/specs/application-settings-ui/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Variables section in Preferences UI
+
+The Preferences screen SHALL include a "Variables" section that allows users to manage global build action variables stored in instance settings.
+
+#### Scenario: Viewing existing variables
+- **WHEN** user navigates to Preferences > Variables
+- **THEN** the system SHALL display a table showing all defined variable names and values
+- **AND** each row SHALL have a delete button
+
+#### Scenario: Adding a new variable
+- **WHEN** user clicks "Add Variable" and enters a name and value
+- **THEN** the system SHALL save the variable to `instance_settings.json` under `variables`
+- **AND** the table SHALL update to show the new variable
+- **AND** a success snackbar SHALL confirm the save
+
+#### Scenario: Editing an existing variable value
+- **WHEN** user modifies the value of an existing variable and saves
+- **THEN** the system SHALL update the variable in `instance_settings.json`
+- **AND** a success snackbar SHALL confirm the update
+
+#### Scenario: Removing a variable
+- **WHEN** user clicks the delete button on a variable row
+- **THEN** the system SHALL remove the variable from `instance_settings.json`
+- **AND** the table SHALL update to reflect the removal
+
+#### Scenario: Empty state
+- **WHEN** no variables are defined
+- **THEN** the system SHALL display an empty state message explaining what variables are for
+- **AND** the "Add Variable" button SHALL be visible
+
+#### Scenario: Variable name validation
+- **WHEN** user enters a variable name with spaces or special characters (other than underscores)
+- **THEN** the system SHALL show a validation error
+- **AND** the variable SHALL NOT be saved
+
+#### Scenario: Duplicate variable name
+- **WHEN** user tries to add a variable with a name that already exists
+- **THEN** the system SHALL show a validation error indicating the name is already in use

--- a/openspec/changes/archive/2026-04-24-restore-global-build-variables/specs/backend-architecture/spec.md
+++ b/openspec/changes/archive/2026-04-24-restore-global-build-variables/specs/backend-architecture/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Global build action variables in instance settings
+
+The `instanceSettingsSchema` SHALL include a `variables` field of type `z.record(z.string(), z.string()).default({})` for storing global build action variables.
+
+#### Scenario: Instance settings with variables
+- **WHEN** `instance_settings.json` contains a `variables` object with key-value pairs
+- **THEN** the system SHALL parse and validate them as `Record<string, string>`
+- **AND** the variables SHALL be accessible via `unifiedConfig.getInstanceSetting('variables')`
+
+#### Scenario: Instance settings without variables
+- **WHEN** `instance_settings.json` has no `variables` field
+- **THEN** the system SHALL default to an empty object `{}`
+- **AND** build actions SHALL still work using only their YAML-defined defaults
+
+### Requirement: Variable merge with global override precedence
+
+When executing a build action, `WorkspaceService` SHALL merge global variables from instance settings with per-action YAML variables. Global variables SHALL take precedence over YAML defaults when both define the same variable name.
+
+#### Scenario: Global variable overrides YAML default
+- **WHEN** a build action defines `execute.variables: [{name: "NIX_EXEC", value: "/usr/bin/nix"}]`
+- **AND** instance settings defines `variables: {"NIX_EXEC": "/run/current-system/sw/bin/nix"}`
+- **THEN** `%NIX_EXEC` SHALL be replaced with `/run/current-system/sw/bin/nix` (global wins)
+
+#### Scenario: YAML variable with no global override
+- **WHEN** a build action defines `execute.variables: [{name: "MY_VAR", value: "default_value"}]`
+- **AND** instance settings does not define `MY_VAR`
+- **THEN** `%MY_VAR` SHALL be replaced with `default_value` (YAML default used)
+
+#### Scenario: Global variable with no YAML counterpart
+- **WHEN** instance settings defines `variables: {"EXTRA_VAR": "extra_value"}`
+- **AND** the build action does not define `EXTRA_VAR` in `execute.variables`
+- **THEN** `%EXTRA_VAR` SHALL be replaced with `extra_value` in command and args
+
+#### Scenario: Built-in variables are not overridable by global variables
+- **WHEN** instance settings defines `variables: {"SITE_PATH": "/malicious/path"}`
+- **THEN** `%SITE_PATH` SHALL still resolve to the actual workspace site path
+- **AND** the built-in replacement SHALL take precedence over custom variables
+
+### Requirement: WorkspaceService passes global variables to BuildActionService
+
+`WorkspaceService.buildSingle()` and `WorkspaceService.buildCollectionItem()` SHALL read global variables from instance settings and pass them to `BuildActionService.runAction()` merged with the per-action YAML variables.
+
+#### Scenario: buildSingle with global variables
+- **WHEN** `buildSingle()` is called
+- **THEN** it SHALL read global variables from `unifiedConfig.getInstanceSetting('variables')`
+- **AND** merge them with `executeDict.variables` (global overriding YAML defaults)
+- **AND** pass the merged variables to `BuildActionService.runAction()`
+
+#### Scenario: buildCollectionItem with global variables
+- **WHEN** `buildCollectionItem()` is called
+- **THEN** it SHALL follow the same merge and pass pattern as `buildSingle()`

--- a/openspec/changes/archive/2026-04-24-restore-global-build-variables/tasks.md
+++ b/openspec/changes/archive/2026-04-24-restore-global-build-variables/tasks.md
@@ -1,0 +1,23 @@
+## 1. Schema: Add variables to instance settings
+
+- [x] 1.1 Add `variables: z.record(z.string(), z.string()).default({})` to `instanceSettingsSchema` in `packages/types/src/schemas/config.ts`
+- [x] 1.2 Rebuild types package (`npm run build -w @quiqr/types`)
+
+## 2. Backend: Merge global variables into build action execution
+
+- [x] 2.1 In `WorkspaceService.buildSingle()`, read global variables from `this.container.unifiedConfig.getInstanceSetting('variables')` and merge with `executeDict.variables` (global overrides YAML defaults) before passing to `buildActionService.runAction()`
+- [x] 2.2 In `WorkspaceService.buildCollectionItem()`, apply the same merge pattern
+- [x] 2.3 Write a unit test verifying that global variables override YAML defaults and that YAML-only and global-only variables both work
+
+## 3. Frontend: Variables preferences UI
+
+- [x] 3.1 Create `PrefsVariables.tsx` in `packages/frontend/src/containers/Prefs/` — table of variable name-value pairs with add, edit, and delete. Follow `PrefsGit.tsx` pattern for instance settings mutation.
+- [x] 3.2 Add variable name validation: alphanumeric and underscores only, no duplicates
+- [x] 3.3 Add empty state message explaining what variables are and how they're used in build actions
+- [x] 3.4 Register the Variables section in the Preferences navigation/routing
+
+## 4. Verification
+
+- [x] 4.1 Verify TypeScript compiles cleanly for both backend and frontend
+- [x] 4.2 Test end-to-end: define a global variable in Preferences, run a build action that uses it, verify the global value is used instead of the YAML default
+- [x] 4.3 Run all existing tests to verify no regressions

--- a/openspec/specs/adapters/spec.md
+++ b/openspec/specs/adapters/spec.md
@@ -213,3 +213,77 @@ The Electron adapter SHALL explicitly disable authentication.
 - **AND** no auth middleware SHALL be active
 - **AND** no auth-related config SHALL be read or written
 
+### Requirement: QUIQR_DATA_DIR environment variable
+
+The standalone adapter SHALL support a `QUIQR_DATA_DIR` environment variable that overrides the default data directory (`~/.quiqr-standalone`).
+
+#### Scenario: QUIQR_DATA_DIR is set
+- **WHEN** the `QUIQR_DATA_DIR` environment variable is set to `/var/lib/quiqr`
+- **THEN** the server SHALL use `/var/lib/quiqr` as the `userDataPath`
+- **AND** all data files (config, logs, sites, runtime state) SHALL be stored under that directory
+
+#### Scenario: QUIQR_DATA_DIR is not set
+- **WHEN** the `QUIQR_DATA_DIR` environment variable is not set
+- **THEN** the server SHALL default to `~/.quiqr-standalone` (unchanged behavior)
+
+### Requirement: HOST / BIND_ADDRESS environment variable
+
+The standalone adapter SHALL support `HOST` and `BIND_ADDRESS` environment variables to control the server bind address. `HOST` SHALL take precedence over `BIND_ADDRESS`.
+
+#### Scenario: HOST is set
+- **WHEN** the `HOST` environment variable is set to `127.0.0.1`
+- **THEN** the server SHALL bind to `127.0.0.1` only
+- **AND** the server SHALL NOT be accessible from other network interfaces
+
+#### Scenario: BIND_ADDRESS is set (HOST not set)
+- **WHEN** `HOST` is not set and `BIND_ADDRESS` is set to `127.0.0.1`
+- **THEN** the server SHALL bind to `127.0.0.1`
+
+#### Scenario: Neither HOST nor BIND_ADDRESS is set
+- **WHEN** neither environment variable is set
+- **THEN** the server SHALL bind to `0.0.0.0` (all interfaces, unchanged behavior)
+
+### Requirement: Server bind address in ServerOptions
+
+`ServerOptions` in `server.ts` SHALL accept an optional `host` parameter. `startServer()` SHALL pass it to `app.listen(port, host)`.
+
+#### Scenario: host provided in ServerOptions
+- **WHEN** `startServer()` is called with `{ host: '127.0.0.1', port: 5150 }`
+- **THEN** Express SHALL listen on `127.0.0.1:5150`
+
+#### Scenario: host not provided in ServerOptions
+- **WHEN** `startServer()` is called without a `host` option
+- **THEN** Express SHALL listen on all interfaces (Express default behavior)
+
+### Requirement: Separate runtime state from config
+
+The standalone adapter SHALL separate server-managed runtime state from read-only configuration by using a dedicated `runtime_state.json` file in the data directory.
+
+#### Scenario: Session secret auto-generation
+- **WHEN** the server starts and no session secret exists in `runtime_state.json`
+- **THEN** the server SHALL generate a random session secret
+- **AND** persist it to `runtime_state.json` (NOT `instance_settings.json`)
+
+#### Scenario: Session secret persistence across restarts
+- **WHEN** the server restarts and `runtime_state.json` contains a session secret
+- **THEN** the server SHALL reuse the persisted secret
+- **AND** existing user sessions SHALL remain valid
+
+#### Scenario: External config not overwritten
+- **WHEN** the server starts with a NixOS-managed `instance_settings.json`
+- **THEN** the server SHALL NOT write to `instance_settings.json`
+- **AND** only `runtime_state.json` SHALL be written by the server
+
+### Requirement: QUIQR_CONFIG_FILE environment variable
+
+The standalone adapter SHALL support a `QUIQR_CONFIG_FILE` environment variable to specify an external config file path.
+
+#### Scenario: QUIQR_CONFIG_FILE is set
+- **WHEN** `QUIQR_CONFIG_FILE` is set to `/etc/quiqr/instance_settings.json`
+- **THEN** the server SHALL copy that file to `<userDataPath>/instance_settings.json` on startup
+- **AND** the unified config service SHALL read from the copied file
+
+#### Scenario: QUIQR_CONFIG_FILE is not set
+- **WHEN** `QUIQR_CONFIG_FILE` is not set
+- **THEN** the server SHALL read config from `<userDataPath>/instance_settings.json` (unchanged behavior)
+

--- a/openspec/specs/application-settings-ui/spec.md
+++ b/openspec/specs/application-settings-ui/spec.md
@@ -93,3 +93,42 @@ The Application Settings menu group SHALL support adding additional settings pag
 - **WHEN** a new settings page is added
 - **THEN** developer can add it to the menu items array in PrefsSidebar without structural changes
 
+### Requirement: Variables section in Preferences UI
+
+The Preferences screen SHALL include a "Variables" section that allows users to manage global build action variables stored in instance settings.
+
+#### Scenario: Viewing existing variables
+- **WHEN** user navigates to Preferences > Variables
+- **THEN** the system SHALL display a table showing all defined variable names and values
+- **AND** each row SHALL have a delete button
+
+#### Scenario: Adding a new variable
+- **WHEN** user clicks "Add Variable" and enters a name and value
+- **THEN** the system SHALL save the variable to `instance_settings.json` under `variables`
+- **AND** the table SHALL update to show the new variable
+- **AND** a success snackbar SHALL confirm the save
+
+#### Scenario: Editing an existing variable value
+- **WHEN** user modifies the value of an existing variable and saves
+- **THEN** the system SHALL update the variable in `instance_settings.json`
+- **AND** a success snackbar SHALL confirm the update
+
+#### Scenario: Removing a variable
+- **WHEN** user clicks the delete button on a variable row
+- **THEN** the system SHALL remove the variable from `instance_settings.json`
+- **AND** the table SHALL update to reflect the removal
+
+#### Scenario: Empty state
+- **WHEN** no variables are defined
+- **THEN** the system SHALL display an empty state message explaining what variables are for
+- **AND** the "Add Variable" button SHALL be visible
+
+#### Scenario: Variable name validation
+- **WHEN** user enters a variable name with spaces or special characters (other than underscores)
+- **THEN** the system SHALL show a validation error
+- **AND** the variable SHALL NOT be saved
+
+#### Scenario: Duplicate variable name
+- **WHEN** user tries to add a variable with a name that already exists
+- **THEN** the system SHALL show a validation error indicating the name is already in use
+

--- a/openspec/specs/backend-architecture/spec.md
+++ b/openspec/specs/backend-architecture/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 The backend architecture defines how Quiqr Desktop's server-side code is organized, built, and deployed across multiple platforms using TypeScript, ESM, and NPM workspaces.
-
 ## Requirements
-
 ### Requirement: TypeScript + ESM Backend
 
 The backend SHALL be written in TypeScript and use ESM (ES Modules) instead of CommonJS.
@@ -106,4 +104,56 @@ The system SHALL support two distribution patterns: standalone binaries and npm 
 - **THEN** it SHALL use async generator pattern yielding progress objects
 - **AND** progress SHALL be streamed via SSE to frontend
 - **AND** supports graceful cancellation
+
+### Requirement: Global build action variables in instance settings
+
+The `instanceSettingsSchema` SHALL include a `variables` field of type `z.record(z.string(), z.string()).default({})` for storing global build action variables.
+
+#### Scenario: Instance settings with variables
+- **WHEN** `instance_settings.json` contains a `variables` object with key-value pairs
+- **THEN** the system SHALL parse and validate them as `Record<string, string>`
+- **AND** the variables SHALL be accessible via `unifiedConfig.getInstanceSetting('variables')`
+
+#### Scenario: Instance settings without variables
+- **WHEN** `instance_settings.json` has no `variables` field
+- **THEN** the system SHALL default to an empty object `{}`
+- **AND** build actions SHALL still work using only their YAML-defined defaults
+
+### Requirement: Variable merge with global override precedence
+
+When executing a build action, `WorkspaceService` SHALL merge global variables from instance settings with per-action YAML variables. Global variables SHALL take precedence over YAML defaults when both define the same variable name.
+
+#### Scenario: Global variable overrides YAML default
+- **WHEN** a build action defines `execute.variables: [{name: "NIX_EXEC", value: "/usr/bin/nix"}]`
+- **AND** instance settings defines `variables: {"NIX_EXEC": "/run/current-system/sw/bin/nix"}`
+- **THEN** `%NIX_EXEC` SHALL be replaced with `/run/current-system/sw/bin/nix` (global wins)
+
+#### Scenario: YAML variable with no global override
+- **WHEN** a build action defines `execute.variables: [{name: "MY_VAR", value: "default_value"}]`
+- **AND** instance settings does not define `MY_VAR`
+- **THEN** `%MY_VAR` SHALL be replaced with `default_value` (YAML default used)
+
+#### Scenario: Global variable with no YAML counterpart
+- **WHEN** instance settings defines `variables: {"EXTRA_VAR": "extra_value"}`
+- **AND** the build action does not define `EXTRA_VAR` in `execute.variables`
+- **THEN** `%EXTRA_VAR` SHALL be replaced with `extra_value` in command and args
+
+#### Scenario: Built-in variables are not overridable by global variables
+- **WHEN** instance settings defines `variables: {"SITE_PATH": "/malicious/path"}`
+- **THEN** `%SITE_PATH` SHALL still resolve to the actual workspace site path
+- **AND** the built-in replacement SHALL take precedence over custom variables
+
+### Requirement: WorkspaceService passes global variables to BuildActionService
+
+`WorkspaceService.buildSingle()` and `WorkspaceService.buildCollectionItem()` SHALL read global variables from instance settings and pass them to `BuildActionService.runAction()` merged with the per-action YAML variables.
+
+#### Scenario: buildSingle with global variables
+- **WHEN** `buildSingle()` is called
+- **THEN** it SHALL read global variables from `unifiedConfig.getInstanceSetting('variables')`
+- **AND** merge them with `executeDict.variables` (global overriding YAML defaults)
+- **AND** pass the merged variables to `BuildActionService.runAction()`
+
+#### Scenario: buildCollectionItem with global variables
+- **WHEN** `buildCollectionItem()` is called
+- **THEN** it SHALL follow the same merge and pass pattern as `buildSingle()`
 

--- a/openspec/specs/communication-layer/spec.md
+++ b/openspec/specs/communication-layer/spec.md
@@ -78,3 +78,35 @@ SSE endpoints SHALL accept JWT tokens via query parameter since `EventSource` ca
 - **AND** auth is enabled
 - **THEN** the backend SHALL respond with 401
 
+### Requirement: File download endpoint with path restriction
+
+The backend SHALL expose a file download endpoint that streams a file from the workspace's site directory, with path traversal protection.
+
+#### Scenario: Valid file download within site directory
+- **WHEN** a GET request is made to `/api/sites/:siteKey/workspaces/:workspaceKey/file-download` with a `path` query parameter
+- **AND** the resolved path is within the workspace's site root directory
+- **THEN** the server SHALL stream the file with `Content-Disposition: attachment; filename="<basename>"`
+- **AND** the response SHALL include an appropriate `Content-Type` header
+
+#### Scenario: Path traversal attempt
+- **WHEN** a GET request is made to the file-download endpoint
+- **AND** the resolved path (after `fs.realpath()`) is outside the workspace's site root directory
+- **THEN** the server SHALL respond with HTTP 403 Forbidden
+- **AND** the response SHALL NOT reveal the resolved path
+
+#### Scenario: File does not exist
+- **WHEN** a GET request is made to the file-download endpoint
+- **AND** the specified file does not exist
+- **THEN** the server SHALL respond with HTTP 404 Not Found
+
+#### Scenario: Path with symlinks
+- **WHEN** the requested path contains symlinks
+- **THEN** the server SHALL resolve the full real path before checking it is within the site directory
+- **AND** if the resolved path is outside the site directory, the server SHALL respond with HTTP 403
+
+#### Scenario: Authentication required
+- **WHEN** a GET request is made to the file-download endpoint
+- **AND** the request is in standalone mode with authentication enabled
+- **THEN** the endpoint SHALL require valid authentication (JWT token)
+- **AND** unauthenticated requests SHALL receive HTTP 401
+

--- a/openspec/specs/frontend-components/spec.md
+++ b/openspec/specs/frontend-components/spec.md
@@ -643,3 +643,76 @@ The frontend API client SHALL provide methods for loading field prompt templates
 - **AND** the function SHALL return AI-generated content string
 - **AND** the function SHALL use proper TypeScript types
 
+### Requirement: Build action buttons in SukohForm
+
+SukohForm SHALL render a `LoadingButton` for each entry in the `buildActions` prop. Buttons SHALL be positioned in the top-right action bar alongside the PAGE ASSIST button. The button label SHALL use `button_text`, falling back to `title`, then `key`.
+
+#### Scenario: Build actions defined in model
+- **WHEN** a single or collection has `build_actions` defined in its model config
+- **THEN** SukohForm SHALL render one `LoadingButton` per build action in the top-right area
+- **AND** each button SHALL display the action's `button_text` (or `title`, or `key` as fallback)
+
+#### Scenario: No build actions defined
+- **WHEN** a single or collection has no `build_actions` or an empty array
+- **THEN** SukohForm SHALL not render any build action buttons
+- **AND** the PAGE ASSIST button (if present) SHALL remain unaffected
+
+#### Scenario: Build action button clicked
+- **WHEN** user clicks a build action button
+- **THEN** the system SHALL auto-save the form if there are unsaved changes
+- **AND** after save completes, the system SHALL call the `onDocBuild` callback with the `BuildAction` object
+- **AND** the clicked button SHALL show a loading spinner until the build completes
+
+#### Scenario: Multiple build actions
+- **WHEN** multiple build actions are defined
+- **THEN** each SHALL have its own independent loading state
+- **AND** clicking one button SHALL NOT disable or affect other build action buttons
+
+### Requirement: Build action result handling in Single and CollectionItem containers
+
+`Single.tsx` and `CollectionItem.tsx` SHALL pass an `onDocBuild` handler to `SukohForm` that calls `api.buildSingle()` or `api.buildCollectionItem()` respectively, and handles the result.
+
+#### Scenario: Successful build action on a single
+- **WHEN** a build action completes successfully on a single
+- **THEN** the container SHALL show a success snackbar with the action name
+- **AND** the build output SHALL be available in the console output panel
+
+#### Scenario: Successful build action on a collection item
+- **WHEN** a build action completes successfully on a collection item
+- **THEN** the container SHALL show a success snackbar with the action name
+- **AND** the build output SHALL be available in the console output panel
+
+#### Scenario: Build action returns file_path stdout type
+- **WHEN** a build action completes with `stdout_type === "file_path"`
+- **THEN** the system SHALL trigger a file download via the file-download endpoint
+- **AND** the file path from stdout SHALL be passed to the download endpoint
+
+#### Scenario: Build action fails
+- **WHEN** a build action fails (non-zero exit code or error)
+- **THEN** the container SHALL show an error snackbar with the action name and error message
+- **AND** any stderr output SHALL be displayed in the console output panel
+
+### Requirement: Build action console output panel
+
+SukohForm SHALL include a collapsible `BuildActionOutput` component that displays stdout and stderr from the most recent build action execution.
+
+#### Scenario: Build action produces output
+- **WHEN** a build action completes (success or error)
+- **AND** there is stdout or stderr content
+- **THEN** the console output panel SHALL appear below the form fields
+- **AND** stdout SHALL be displayed in a monospace `<pre>` block
+- **AND** stderr SHALL be visually distinct (e.g., red text or separate section)
+
+#### Scenario: Dismiss console output
+- **WHEN** the user clicks the dismiss/close button on the console output panel
+- **THEN** the panel SHALL collapse and hide
+
+#### Scenario: Large output truncation
+- **WHEN** build output exceeds 500 lines
+- **THEN** the panel SHALL display only the last 500 lines
+- **AND** a message SHALL indicate that output was truncated
+
+#### Scenario: New build action replaces previous output
+- **WHEN** a new build action is executed while previous output is displayed
+- **THEN** the previous output SHALL be replaced with the new output
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quiqr",
-  "version": "0.22.7",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quiqr",
-      "version": "0.22.7",
+      "version": "0.23.0",
       "license": "MIT",
       "workspaces": [
         "packages/types",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/quiqr/quiqr-desktop.git"
   },
   "description": "Local-first CMS for static files and engines like Quarto or Hugo SSG",
-  "version": "0.22.7",
+  "version": "0.23.0",
   "main": "packages/adapters/electron/dist/main.js",
   "scripts": {
     "clean": "rm -rf node_modules dist build packages/frontend/node_modules packages/frontend/dist packages/frontend/build packages/types/node_modules packages/types/dist packages/types/build packages/backend/node_modules packages/backend/dist packages/backend/build packages/adapters/electron/node_modules packages/adapters/electron/dist packages/adapters/electron/build packages/adapters/standalone/node_modules packages/adapters/standalone/dist packages/adapters/standalone/build packages/types/tsconfig.tsbuildinfo packages/backend/tsconfig.tsbuildinfo packages/frontend/tsconfig.tsbuildinfo packages/adapters/electron/tsconfig.tsbuildinfo packages/adapters/standalone/tsconfig.tsbuildinfo",

--- a/packages/adapters/standalone/src/main.ts
+++ b/packages/adapters/standalone/src/main.ts
@@ -15,7 +15,7 @@ import { randomBytes } from 'crypto';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from 'fs';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -65,14 +65,32 @@ async function startStandaloneBackend() {
 
   try {
     // Get paths
-    // For standalone mode, use a dedicated directory in user's home
-    const userDataPath = join(homedir(), '.quiqr-standalone');
+    // For standalone mode, use QUIQR_DATA_DIR env var or default to ~/.quiqr-standalone
+    const userDataPath = process.env.QUIQR_DATA_DIR
+      || join(homedir(), '.quiqr-standalone');
 
     // Find the project root (where resources folder is located)
     const rootPath = findProjectRoot();
 
     console.log(`User Data: ${userDataPath}`);
     console.log(`Root Path: ${rootPath}`);
+
+    // Ensure data directory exists
+    mkdirSync(userDataPath, { recursive: true });
+
+    // If QUIQR_CONFIG_FILE is set, copy external config into the data directory
+    // so the unified config service reads from its expected location.
+    const externalConfigFile = process.env.QUIQR_CONFIG_FILE;
+    if (externalConfigFile) {
+      const targetPath = join(userDataPath, 'instance_settings.json');
+      try {
+        copyFileSync(externalConfigFile, targetPath);
+        console.log(`Config copied from ${externalConfigFile}`);
+      } catch (e) {
+        console.error(`Failed to copy config from ${externalConfigFile}:`, e);
+        process.exit(1);
+      }
+    }
 
     // Create container first with dev adapters (temporary)
     const container = createContainer({
@@ -93,21 +111,35 @@ async function startStandaloneBackend() {
       { enabled?: boolean; provider?: string; local?: { usersFile?: string }; session?: { secret?: string; accessTokenExpiry?: string; refreshTokenExpiry?: string } } | undefined;
 
     if (authConfig?.enabled) {
-      // Auto-generate session secret if not set
-      let secret = authConfig.session?.secret;
+      // Read session secret from runtime state (not instance_settings.json).
+      // This separation allows instance_settings.json to be externally managed
+      // (e.g., by NixOS) without the server overwriting it.
+      const runtimeStatePath = join(userDataPath, 'runtime_state.json');
+      let runtimeState: Record<string, unknown> = {};
+      try {
+        if (existsSync(runtimeStatePath)) {
+          runtimeState = JSON.parse(readFileSync(runtimeStatePath, 'utf-8'));
+        }
+      } catch {
+        runtimeState = {};
+      }
+
+      // Use secret from: runtime state > config > generate new
+      let secret = (runtimeState.sessionSecret as string)
+        || authConfig.session?.secret;
+
       if (!secret) {
         secret = randomBytes(32).toString('hex');
-        // Persist the generated secret to instance settings
-        const settingsPath = join(userDataPath, 'instance_settings.json');
+      }
+
+      // Always persist to runtime state (ensures it survives config regeneration)
+      if (runtimeState.sessionSecret !== secret) {
         try {
-          const current = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, 'utf-8')) : {};
-          if (!current.auth) current.auth = {};
-          if (!current.auth.session) current.auth.session = {};
-          current.auth.session.secret = secret;
-          writeFileSync(settingsPath, JSON.stringify(current, null, 2), 'utf-8');
-          console.log('Generated and persisted auth session secret.');
+          runtimeState.sessionSecret = secret;
+          writeFileSync(runtimeStatePath, JSON.stringify(runtimeState, null, 2), 'utf-8');
+          console.log('Session secret persisted to runtime_state.json.');
         } catch (e) {
-          console.warn('Could not persist session secret to instance settings:', e);
+          console.warn('Could not persist session secret to runtime_state.json:', e);
         }
       }
 
@@ -148,8 +180,9 @@ async function startStandaloneBackend() {
 
     console.log('Web adapters initialized (menu, window, appInfo)');
 
-    // Get port from environment or use default
+    // Get port and host from environment or use defaults
     const port = process.env.PORT ? parseInt(process.env.PORT) : 5150;
+    const host = process.env.HOST || process.env.BIND_ADDRESS || undefined;
 
     // Initialize structured logger
     const prefs = container.config.prefs;
@@ -180,7 +213,7 @@ async function startStandaloneBackend() {
     }
 
     // Start the Express server
-    startServer(container, { port, frontendPath, auth });
+    startServer(container, { port, host, frontendPath, auth });
 
     container.logger.info(GLOBAL_CATEGORIES.STANDALONE_INIT, 'Quiqr Backend ready', {
       api: `http://localhost:${port}`,

--- a/packages/backend/src/api/handlers/file-download-handler.ts
+++ b/packages/backend/src/api/handlers/file-download-handler.ts
@@ -1,0 +1,80 @@
+/**
+ * File Download Handler
+ *
+ * Serves files from within the workspace's site directory for browser download.
+ * Includes path traversal protection: only files under the site root are served.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Request, Response } from 'express';
+import type { AppContainer } from '../../config/container.js';
+
+/**
+ * Create a GET handler for file downloads restricted to the workspace site directory.
+ *
+ * Security:
+ * - Resolves the requested path with fs.realpath() to eliminate symlinks and .. sequences
+ * - Verifies the resolved path starts with the workspace's site root
+ * - Rejects paths outside the site directory with 403
+ */
+export function createFileDownloadHandler(container: AppContainer) {
+  return async (req: Request, res: Response) => {
+    const { siteKey, workspaceKey } = req.params;
+    const filePath = req.query.path;
+
+    if (typeof siteKey !== 'string' || typeof workspaceKey !== 'string') {
+      res.status(400).json({ error: 'Invalid site or workspace key' });
+      return;
+    }
+
+    if (typeof filePath !== 'string' || filePath.length === 0) {
+      res.status(400).json({ error: 'Missing or invalid path parameter' });
+      return;
+    }
+
+    try {
+      const workspaceService = await container.getWorkspaceService(siteKey, workspaceKey);
+      const siteRoot = workspaceService.getWorkspacePath();
+
+      // Resolve the site root to its real path (no symlinks)
+      const realSiteRoot = await fs.promises.realpath(siteRoot);
+
+      // If the path is relative, resolve it against the site root
+      const targetPath = path.isAbsolute(filePath)
+        ? filePath
+        : path.join(realSiteRoot, filePath);
+
+      // Check the file exists before resolving realpath
+      try {
+        await fs.promises.access(targetPath, fs.constants.R_OK);
+      } catch {
+        res.status(404).json({ error: 'File not found' });
+        return;
+      }
+
+      // Resolve to real path (eliminates symlinks and .. sequences)
+      const realPath = await fs.promises.realpath(targetPath);
+
+      // Verify the resolved path is within the site root
+      if (!realPath.startsWith(realSiteRoot + path.sep) && realPath !== realSiteRoot) {
+        res.status(403).json({ error: 'Access denied' });
+        return;
+      }
+
+      // Stream the file as a download
+      const filename = path.basename(realPath);
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      const stream = fs.createReadStream(realPath);
+      stream.pipe(res);
+      stream.on('error', () => {
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Error reading file' });
+        }
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(500).json({ error: message });
+    }
+  };
+}

--- a/packages/backend/src/api/server.ts
+++ b/packages/backend/src/api/server.ts
@@ -14,6 +14,7 @@ import { errorHandler, asyncHandler } from './middleware/error-handler.js';
 import { createAuthMiddleware } from './middleware/auth-middleware.js';
 import { createAuthRoutes } from './routes/auth-routes.js';
 import { TokenService } from '../auth/token-service.js';
+import { createFileDownloadHandler } from './handlers/file-download-handler.js';
 
 /**
  * Server configuration options
@@ -33,6 +34,12 @@ export interface ServerOptions {
    * Port to listen on (default: 5150)
    */
   port?: number;
+
+  /**
+   * Host/address to bind to (default: '0.0.0.0' — all interfaces).
+   * Set to '127.0.0.1' when running behind a reverse proxy.
+   */
+  host?: string;
 
   /**
    * Enable CORS. Defaults to true when frontendPath is not set,
@@ -339,6 +346,12 @@ export function createServer(
     }
   );
 
+  // File download route — serves files from within the workspace site directory
+  app.get(
+    '/api/sites/:siteKey/workspaces/:workspaceKey/file-download',
+    createFileDownloadHandler(container)
+  );
+
   // SPA catch-all: serve index.html for any non-API route (public)
   if (frontendPath) {
     app.get('/{*path}', (req, res) => {
@@ -363,15 +376,23 @@ export function startServer(
   container: AppContainer,
   options: ServerOptions = {}
 ): void {
-  const { port = 5150 } = options;
+  const { port = 5150, host } = options;
 
   const app = createServer(container, options);
 
-  app.listen(port, () => {
+  const onListening = () => {
+    const bindAddress = host || '0.0.0.0';
     container.logger.info('backend-server', 'API Server started', {
       port,
-      url: `http://localhost:${port}`
+      host: bindAddress,
+      url: `http://${bindAddress === '0.0.0.0' ? 'localhost' : bindAddress}:${port}`
     });
-    console.log(`Server running on http://localhost:${port}`);
-  });
+    console.log(`Server running on http://${bindAddress}:${port}`);
+  };
+
+  if (host) {
+    app.listen(port, host, onListening);
+  } else {
+    app.listen(port, onListening);
+  }
 }

--- a/packages/backend/src/config/__tests__/config-resolver-simplified.test.ts
+++ b/packages/backend/src/config/__tests__/config-resolver-simplified.test.ts
@@ -271,6 +271,7 @@ describe('ConfigResolver - Simplified 2-Layer', () => {
           serveDraftMode: false,
           disableAutoHugoServe: false,
         },
+        variables: {},
       };
       await store.writeInstanceSettings(completeInstanceSettings);
 

--- a/packages/backend/src/config/config-resolver.ts
+++ b/packages/backend/src/config/config-resolver.ts
@@ -39,6 +39,7 @@ const APP_DEFAULT_INSTANCE: InstanceSettings = {
     serveDraftMode: false,
     disableAutoHugoServe: false,
   },
+  variables: {},
 };
 
 const APP_DEFAULT_USER_PREFS = {

--- a/packages/backend/src/config/config-store.ts
+++ b/packages/backend/src/config/config-store.ts
@@ -25,6 +25,7 @@ const DEFAULT_INSTANCE_SETTINGS: InstanceSettings = {
   experimentalFeatures: false,
   dev: { localApi: false, showCurrentUser: false, disablePartialCache: false },
   hugo: { serveDraftMode: false, disableAutoHugoServe: false },
+  variables: {},
 };
 
 /**

--- a/packages/backend/src/config/unified-config-service.ts
+++ b/packages/backend/src/config/unified-config-service.ts
@@ -28,6 +28,7 @@ export type DeepPartialInstanceSettings = {
   experimentalFeatures?: boolean;
   dev?: Partial<InstanceSettings['dev']>;
   hugo?: Partial<InstanceSettings['hugo']>;
+  variables?: Record<string, string>;
 };
 
 /**
@@ -336,6 +337,7 @@ export class UnifiedConfigService {
         ...current.hugo,
         ...(updates.hugo || {}),
       },
+      ...(updates.variables !== undefined ? { variables: updates.variables } : {}),
     };
 
     await this.store.writeInstanceSettings(updated);

--- a/packages/backend/src/services/workspace/workspace-config-provider.ts
+++ b/packages/backend/src/services/workspace/workspace-config-provider.ts
@@ -186,6 +186,10 @@ export class WorkspaceConfigProvider {
       throw new Error(validationError);
     }
 
+    // Normalize camelCase keys from site models to snake_case
+    // Existing site models use buildActions (camelCase) but the type system uses build_actions
+    this._normalizeCamelCaseKeys(dataPhase2Merged);
+
     // After successful validation, the config conforms to WorkspaceConfig
     // The cast is safe here because the validator has verified the structure
     return dataPhase2Merged as WorkspaceConfig;
@@ -576,5 +580,29 @@ export class WorkspaceConfigProvider {
 
   getEnvironmentInfo(): EnvironmentInfo {
     return this.environmentInfo;
+  }
+
+  /**
+   * Normalize camelCase keys from site model YAML to snake_case.
+   * Existing site models use buildActions (camelCase) but the type system uses build_actions.
+   */
+  private _normalizeCamelCaseKeys(config: PartialWorkspaceConfig): void {
+    const normalizeItem = (item: Record<string, unknown>) => {
+      if ('buildActions' in item && !('build_actions' in item)) {
+        item.build_actions = item.buildActions;
+        delete item.buildActions;
+      }
+    };
+
+    if (config.collections) {
+      for (const collection of config.collections) {
+        normalizeItem(collection as Record<string, unknown>);
+      }
+    }
+    if (config.singles) {
+      for (const single of config.singles) {
+        normalizeItem(single as Record<string, unknown>);
+      }
+    }
   }
 }

--- a/packages/backend/src/services/workspace/workspace-service.ts
+++ b/packages/backend/src/services/workspace/workspace-service.ts
@@ -23,6 +23,7 @@ import type { PathHelper } from '../../utils/path-helper.js';
 import { recurForceRemove } from '../../utils/file-dir-utils.js';
 import { createThumbnailJob } from '../../jobs/index.js';
 import { BuildActionService, type BuildActionResult } from '../../build-actions/index.js';
+import type { BuildActionExecute } from '@quiqr/types';
 import { SITE_CATEGORIES } from '../../logging/index.js';
 import type { CollectionConfig, ExtraBuildConfig, BuildConfig, ServeConfig } from '@quiqr/types';
 import { frontMatterContentSchema } from '@quiqr/types';
@@ -893,9 +894,13 @@ export class WorkspaceService {
       throw new Error(`Build action ${buildAction} not found in collection ${collectionKey}`);
     }
 
+    // Merge global variables (from instance settings) with per-action YAML variables.
+    // Global overrides YAML defaults.
+    const executeWithMergedVars = this.mergeGlobalVariables(buildActionDict.execute);
+
     return this.buildActionService.runAction(
       buildAction,
-      buildActionDict.execute,
+      executeWithMergedVars,
       filePath,
       this.workspacePath,
       this.siteKey,
@@ -919,14 +924,48 @@ export class WorkspaceService {
       throw new Error(`Build action ${buildAction} not found in single ${singleKey}`);
     }
 
+    // Merge global variables (from instance settings) with per-action YAML variables.
+    // Global overrides YAML defaults.
+    const executeWithMergedVars = this.mergeGlobalVariables(buildActionDict.execute);
+
     return this.buildActionService.runAction(
       buildAction,
-      buildActionDict.execute,
+      executeWithMergedVars,
       filePath,
       this.workspacePath,
       this.siteKey,
       this.workspaceKey
     );
+  }
+
+  /**
+   * Merge global variables from instance settings with per-action YAML variables.
+   * Global variables override YAML defaults when both define the same name.
+   */
+  private mergeGlobalVariables(execute: BuildActionExecute): BuildActionExecute {
+    const globalVars = this.container.unifiedConfig.getInstanceSetting('variables') as Record<string, string> | undefined;
+    if (!globalVars || Object.keys(globalVars).length === 0) {
+      return execute;
+    }
+
+    // Start with YAML defaults, then overlay global overrides
+    const yamlVars = execute.variables || [];
+    const mergedMap = new Map<string, string>();
+
+    // Add YAML defaults first
+    for (const v of yamlVars) {
+      mergedMap.set(v.name, v.value);
+    }
+
+    // Global overrides win
+    for (const [name, value] of Object.entries(globalVars)) {
+      mergedMap.set(name, value);
+    }
+
+    // Convert back to the array format expected by BuildActionService
+    const mergedVars = Array.from(mergedMap.entries()).map(([name, value]) => ({ name, value }));
+
+    return { ...execute, variables: mergedVars };
   }
 
   /**

--- a/packages/backend/test/api/file-download-handler.test.ts
+++ b/packages/backend/test/api/file-download-handler.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for file-download handler path traversal protection
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createFileDownloadHandler } from '../../src/api/handlers/file-download-handler.js';
+
+function createTestApp(siteRoot: string) {
+  const app = express();
+
+  const mockContainer = {
+    getWorkspaceService: vi.fn().mockResolvedValue({
+      getWorkspacePath: () => siteRoot,
+    }),
+  } as any;
+
+  app.get(
+    '/api/sites/:siteKey/workspaces/:workspaceKey/file-download',
+    createFileDownloadHandler(mockContainer)
+  );
+
+  return app;
+}
+
+describe('File Download Handler', () => {
+  let siteDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    siteDir = mkdtempSync(join(tmpdir(), 'quiqr-test-site-'));
+    outsideDir = mkdtempSync(join(tmpdir(), 'quiqr-test-outside-'));
+
+    // Create a valid file inside the site directory
+    writeFileSync(join(siteDir, 'output.pdf'), 'PDF content');
+
+    // Create a subdirectory with a file
+    mkdirSync(join(siteDir, 'subdir'));
+    writeFileSync(join(siteDir, 'subdir', 'report.html'), '<html>Report</html>');
+
+    // Create a file outside the site directory
+    writeFileSync(join(outsideDir, 'secret.txt'), 'sensitive data');
+  });
+
+  afterEach(() => {
+    rmSync(siteDir, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it('serves a file within the site directory', async () => {
+    const app = createTestApp(siteDir);
+    const res = await request(app)
+      .get('/api/sites/test-site/workspaces/main/file-download')
+      .query({ path: join(siteDir, 'output.pdf') });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toContain('output.pdf');
+    expect(res.text).toBe('PDF content');
+  });
+
+  it('serves a file using a relative path', async () => {
+    const app = createTestApp(siteDir);
+    const res = await request(app)
+      .get('/api/sites/test-site/workspaces/main/file-download')
+      .query({ path: 'subdir/report.html' });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toContain('report.html');
+    expect(res.text).toBe('<html>Report</html>');
+  });
+
+  it('rejects path traversal with .. sequences', async () => {
+    const app = createTestApp(siteDir);
+    const res = await request(app)
+      .get('/api/sites/test-site/workspaces/main/file-download')
+      .query({ path: join(siteDir, '..', 'quiqr-test-outside-something', 'secret.txt') });
+
+    expect(res.status).toBeOneOf([403, 404]);
+  });
+
+  it('rejects absolute path outside site directory', async () => {
+    const app = createTestApp(siteDir);
+    const res = await request(app)
+      .get('/api/sites/test-site/workspaces/main/file-download')
+      .query({ path: join(outsideDir, 'secret.txt') });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects symlink pointing outside site directory', async () => {
+    // Create a symlink inside the site dir pointing to outside
+    const symlinkPath = join(siteDir, 'evil-link.txt');
+    try {
+      symlinkSync(join(outsideDir, 'secret.txt'), symlinkPath);
+    } catch {
+      // Symlink creation may fail on some platforms, skip
+      return;
+    }
+
+    const app = createTestApp(siteDir);
+    const res = await request(app)
+      .get('/api/sites/test-site/workspaces/main/file-download')
+      .query({ path: symlinkPath });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for non-existent file', async () => {
+    const app = createTestApp(siteDir);
+    const res = await request(app)
+      .get('/api/sites/test-site/workspaces/main/file-download')
+      .query({ path: join(siteDir, 'nonexistent.pdf') });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when path parameter is missing', async () => {
+    const app = createTestApp(siteDir);
+    const res = await request(app)
+      .get('/api/sites/test-site/workspaces/main/file-download');
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/backend/test/build-actions/variable-merge.test.ts
+++ b/packages/backend/test/build-actions/variable-merge.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for global variable merge with YAML defaults in build actions.
+ *
+ * Tests the merge strategy: global variables from instance settings
+ * override per-action YAML defaults when both define the same name.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Reimplements the merge logic from WorkspaceService.mergeGlobalVariables()
+ * to test it in isolation without needing a full WorkspaceService instance.
+ */
+function mergeVariables(
+  yamlVars: Array<{ name: string; value: string }> | undefined,
+  globalVars: Record<string, string> | undefined
+): Array<{ name: string; value: string }> {
+  const mergedMap = new Map<string, string>();
+
+  // Add YAML defaults first
+  if (yamlVars) {
+    for (const v of yamlVars) {
+      mergedMap.set(v.name, v.value);
+    }
+  }
+
+  // Global overrides win
+  if (globalVars) {
+    for (const [name, value] of Object.entries(globalVars)) {
+      mergedMap.set(name, value);
+    }
+  }
+
+  return Array.from(mergedMap.entries()).map(([name, value]) => ({ name, value }));
+}
+
+describe('Build Action Variable Merge', () => {
+  it('global variable overrides YAML default', () => {
+    const yamlVars = [{ name: 'NIX_EXEC', value: '/usr/bin/nix' }];
+    const globalVars = { NIX_EXEC: '/run/current-system/sw/bin/nix' };
+
+    const result = mergeVariables(yamlVars, globalVars);
+
+    expect(result).toEqual([
+      { name: 'NIX_EXEC', value: '/run/current-system/sw/bin/nix' },
+    ]);
+  });
+
+  it('YAML variable used when no global override exists', () => {
+    const yamlVars = [{ name: 'MY_VAR', value: 'default_value' }];
+    const globalVars = {};
+
+    const result = mergeVariables(yamlVars, globalVars);
+
+    expect(result).toEqual([
+      { name: 'MY_VAR', value: 'default_value' },
+    ]);
+  });
+
+  it('global-only variable is included', () => {
+    const yamlVars: Array<{ name: string; value: string }> = [];
+    const globalVars = { EXTRA_VAR: 'extra_value' };
+
+    const result = mergeVariables(yamlVars, globalVars);
+
+    expect(result).toEqual([
+      { name: 'EXTRA_VAR', value: 'extra_value' },
+    ]);
+  });
+
+  it('mixed: some overridden, some only in YAML, some only global', () => {
+    const yamlVars = [
+      { name: 'SHARED', value: 'yaml_default' },
+      { name: 'YAML_ONLY', value: 'yaml_value' },
+    ];
+    const globalVars = {
+      SHARED: 'global_override',
+      GLOBAL_ONLY: 'global_value',
+    };
+
+    const result = mergeVariables(yamlVars, globalVars);
+
+    const resultMap = new Map(result.map((v) => [v.name, v.value]));
+    expect(resultMap.get('SHARED')).toBe('global_override');
+    expect(resultMap.get('YAML_ONLY')).toBe('yaml_value');
+    expect(resultMap.get('GLOBAL_ONLY')).toBe('global_value');
+  });
+
+  it('no variables at all returns empty array', () => {
+    const result = mergeVariables(undefined, undefined);
+    expect(result).toEqual([]);
+  });
+
+  it('undefined global vars uses YAML defaults', () => {
+    const yamlVars = [{ name: 'A', value: '1' }];
+    const result = mergeVariables(yamlVars, undefined);
+    expect(result).toEqual([{ name: 'A', value: '1' }]);
+  });
+});

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -267,6 +267,20 @@ export function buildSingle(siteKey: string, workspaceKey: string, singleKey: st
   return request('buildSingle', {siteKey, workspaceKey, singleKey, buildAction});
 }
 
+/**
+ * Trigger a browser download for a file within the workspace's site directory.
+ * Uses a hidden anchor element to initiate the download from the file-download endpoint.
+ */
+export function fileDownload(siteKey: string, workspaceKey: string, filePath: string) {
+  const url = `/api/sites/${encodeURIComponent(siteKey)}/workspaces/${encodeURIComponent(workspaceKey)}/file-download?path=${encodeURIComponent(filePath)}`;
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = '';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
 export function updateCollectionItem(siteKey: string, workspaceKey: string, collectionKey: string, collectionItemKey: string, document: Record<string, unknown>){
   return request('updateCollectionItem', {siteKey, workspaceKey, collectionKey, collectionItemKey, document});
 }
@@ -833,6 +847,7 @@ export interface API {
   openCollectionItemInEditor: typeof openCollectionItemInEditor;
   buildCollectionItem: typeof buildCollectionItem;
   buildSingle: typeof buildSingle;
+  fileDownload: typeof fileDownload;
   updateCollectionItem: typeof updateCollectionItem;
   createCollectionItemKey: typeof createCollectionItemKey;
   deleteCollectionItem: typeof deleteCollectionItem;

--- a/packages/frontend/src/components/SukohForm/BuildActionOutput.tsx
+++ b/packages/frontend/src/components/SukohForm/BuildActionOutput.tsx
@@ -1,0 +1,93 @@
+import { Box, IconButton, Typography } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+const MAX_LINES = 500;
+
+interface BuildOutput {
+  actionName: string;
+  success: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+function truncateOutput(text: string): { text: string; truncated: boolean } {
+  const lines = text.split('\n');
+  if (lines.length <= MAX_LINES) {
+    return { text, truncated: false };
+  }
+  return {
+    text: lines.slice(-MAX_LINES).join('\n'),
+    truncated: true,
+  };
+}
+
+export function BuildActionOutput({
+  output,
+  onDismiss,
+}: {
+  output: BuildOutput;
+  onDismiss: () => void;
+}) {
+  const stdout = truncateOutput(output.stdout);
+  const stderr = truncateOutput(output.stderr);
+
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderColor: output.success ? 'divider' : 'error.main',
+        borderRadius: 1,
+        mt: 2,
+        mb: 2,
+        overflow: 'hidden',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: 2,
+          py: 0.5,
+          bgcolor: output.success ? 'action.hover' : 'error.dark',
+          color: output.success ? 'text.primary' : 'error.contrastText',
+        }}
+      >
+        <Typography variant="subtitle2">
+          {output.actionName} — {output.success ? 'completed' : 'failed'}
+        </Typography>
+        <IconButton size="small" onClick={onDismiss} color="inherit">
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Box>
+
+      {output.stdout && (
+        <Box sx={{ px: 2, py: 1, maxHeight: 300, overflow: 'auto' }}>
+          {stdout.truncated && (
+            <Typography variant="caption" color="text.secondary">
+              Output truncated to last {MAX_LINES} lines
+            </Typography>
+          )}
+          <pre style={{ margin: 0, fontSize: '0.8rem', whiteSpace: 'pre-wrap' }}>
+            {stdout.text}
+          </pre>
+        </Box>
+      )}
+
+      {output.stderr && (
+        <Box sx={{ px: 2, py: 1, maxHeight: 200, overflow: 'auto', bgcolor: 'error.dark' }}>
+          {stderr.truncated && (
+            <Typography variant="caption" color="error.contrastText">
+              Error output truncated to last {MAX_LINES} lines
+            </Typography>
+          )}
+          <pre style={{ margin: 0, fontSize: '0.8rem', whiteSpace: 'pre-wrap', color: '#ffcdd2' }}>
+            {stderr.text}
+          </pre>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export type { BuildOutput };

--- a/packages/frontend/src/components/SukohForm/index.tsx
+++ b/packages/frontend/src/components/SukohForm/index.tsx
@@ -1,12 +1,16 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import Fab from '@mui/material/Fab';
 import Button from '@mui/material/Button';
+import LoadingButton from '@mui/lab/LoadingButton';
 import CheckIcon from '@mui/icons-material/Check';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import BuildIcon from '@mui/icons-material/Build';
 import service from './../../services/service';
 import { FormProvider } from './FormProvider';
 import { FieldRenderer } from './FieldRenderer';
 import { PageAIAssistDialog } from './PageAIAssistDialog';
+import { BuildActionOutput } from './BuildActionOutput';
+import type { BuildOutput } from './BuildActionOutput';
 import { findFieldByPath, pathHasArrayIndex, getTopLevelKey } from '../../utils/findFieldByPath';
 import type { Field, BuildAction } from '@quiqr/types';
 import type { FormMeta } from './FormContext';
@@ -48,7 +52,7 @@ type SukohFormProps = {
   hideExternalEditIcon?: boolean;
   values: Record<string, unknown>;
   onOpenInEditor?: (context?: { reject: (message: string) => void }) => void;
-  onDocBuild?: (buildAction: BuildAction) => void;
+  onDocBuild?: (buildAction: BuildAction) => Promise<{ actionName: string; stdoutType?: string; stdoutContent: string }>;
   onSave?: (context: SaveContext) => void;
   hideSaveButton?: boolean;
   refreshed?: boolean;
@@ -66,6 +70,8 @@ export const SukohForm = ({
   prompt_templates,
   collectionItemKey,
   fields,
+  buildActions,
+  onDocBuild,
   pageUrl,
   values,
   onSave,
@@ -77,6 +83,8 @@ export const SukohForm = ({
   const [, setError] = useState<string | null>(null);
   const [savedOnce, setSavedOnce] = useState(false);
   const [aiAssistOpen, setAiAssistOpen] = useState(false);
+  const [loadingActions, setLoadingActions] = useState<Set<string>>(new Set());
+  const [buildOutput, setBuildOutput] = useState<BuildOutput | null>(null);
   
   // For new form system - track document state and resources
   const newFormDocRef = useRef<Record<string, unknown>>(values || {});
@@ -164,6 +172,46 @@ export const SukohForm = ({
     [saveContent]
   );
 
+  const handleBuildAction = useCallback(
+    async (action: BuildAction) => {
+      if (!onDocBuild) return;
+
+      const actionKey = action.key;
+      setLoadingActions((prev) => new Set(prev).add(actionKey));
+
+      try {
+        // Auto-save if form is dirty
+        if (changed) {
+          saveContent();
+        }
+
+        const result = await onDocBuild(action);
+
+        setBuildOutput({
+          actionName: result.actionName,
+          success: true,
+          stdout: result.stdoutContent || '',
+          stderr: '',
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setBuildOutput({
+          actionName: action.title || action.key,
+          success: false,
+          stdout: '',
+          stderr: message,
+        });
+      } finally {
+        setLoadingActions((prev) => {
+          const next = new Set(prev);
+          next.delete(actionKey);
+          return next;
+        });
+      }
+    },
+    [onDocBuild, changed, saveContent]
+  );
+
   let floatingActionButtonClass = 'animated';
   if (!savedOnce) floatingActionButtonClass += ' zoomIn';
   if (changed) floatingActionButtonClass += ' rubberBand';
@@ -197,35 +245,45 @@ export const SukohForm = ({
 
     // Check if AI Assist should be shown
     const hasPromptTemplates = prompt_templates && Array.isArray(prompt_templates) && prompt_templates.length > 0;
+    const hasBuildActions = buildActions && buildActions.length > 0;
 
     return (
       <>
+        {(hasPromptTemplates || hasBuildActions) && (
+          <div style={{ position: 'absolute', top: 142, right: 16, zIndex: 10, display: 'flex', gap: 8 }}>
+            {hasPromptTemplates && (
+              <Button
+                variant="contained"
+                startIcon={<AutoAwesomeIcon />}
+                onClick={() => setAiAssistOpen(true)}
+              >
+                PAGE ASSIST
+              </Button>
+            )}
+            {hasBuildActions && buildActions.map((action) => (
+              <LoadingButton
+                key={action.key}
+                variant="outlined"
+                startIcon={<BuildIcon />}
+                loading={loadingActions.has(action.key)}
+                onClick={() => handleBuildAction(action)}
+              >
+                {action.button_text || action.title || action.key}
+              </LoadingButton>
+            ))}
+          </div>
+        )}
         {hasPromptTemplates && (
-          <>
-            <Button
-              variant="contained"
-              startIcon={<AutoAwesomeIcon />}
-              onClick={() => setAiAssistOpen(true)}
-              sx={{
-                position: 'absolute',
-                top: 142,
-                right: 16,
-                zIndex: 10,
-              }}
-            >
-              PAGE ASSIST
-            </Button>
-            <PageAIAssistDialog
-              open={aiAssistOpen}
-              onClose={() => setAiAssistOpen(false)}
-              siteKey={siteKey}
-              workspaceKey={workspaceKey}
-              promptTemplateKeys={prompt_templates || []}
-              collectionKey={collectionKey}
-              collectionItemKey={collectionItemKey}
-              singleKey={singleKey}
-            />
-          </>
+          <PageAIAssistDialog
+            open={aiAssistOpen}
+            onClose={() => setAiAssistOpen(false)}
+            siteKey={siteKey}
+            workspaceKey={workspaceKey}
+            promptTemplateKeys={prompt_templates || []}
+            collectionKey={collectionKey}
+            collectionItemKey={collectionItemKey}
+            singleKey={singleKey}
+          />
         )}
         <FormProvider
           fields={fields}
@@ -277,6 +335,12 @@ export const SukohForm = ({
             ))
           )}
         </FormProvider>
+        {buildOutput && (
+          <BuildActionOutput
+            output={buildOutput}
+            onDismiss={() => setBuildOutput(null)}
+          />
+        )}
         {hideSaveButton ? null : fabButton}
         <div style={{ height: '70px' }}></div>
       </>

--- a/packages/frontend/src/containers/Prefs/PrefsRouted.tsx
+++ b/packages/frontend/src/containers/Prefs/PrefsRouted.tsx
@@ -6,6 +6,7 @@ import PrefsApplicationStorage from './PrefsApplicationStorage';
 import PrefsGit from './PrefsGit';
 import PrefsLogging from './PrefsLogging';
 import PrefsHugo from './PrefsHugo';
+import PrefsVariables from './PrefsVariables';
 
 export const PrefsRouted = () => {
   return (
@@ -17,6 +18,7 @@ export const PrefsRouted = () => {
       <Route path="git" element={<PrefsGit />} />
       <Route path="logging" element={<PrefsLogging />} />
       <Route path="hugo" element={<PrefsHugo />} />
+      <Route path="variables" element={<PrefsVariables />} />
       <Route path="*" element={<PrefsGeneral />} />
     </Routes>
   );

--- a/packages/frontend/src/containers/Prefs/PrefsSidebar.tsx
+++ b/packages/frontend/src/containers/Prefs/PrefsSidebar.tsx
@@ -56,6 +56,12 @@ export const PrefsSidebar = (props: PrefsSidebarProps) => {
       },
       {
         active: true,
+        label: 'Variables',
+        to: '/prefs/variables',
+        exact: true,
+      },
+      {
+        active: true,
         label: 'Feature Flags',
         to: '/prefs/appsettings-general',
         exact: true,

--- a/packages/frontend/src/containers/Prefs/PrefsVariables.tsx
+++ b/packages/frontend/src/containers/Prefs/PrefsVariables.tsx
@@ -1,0 +1,192 @@
+import { useState, useEffect } from 'react';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Box from '@mui/material/Box';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import { getInstanceSetting, updateInstanceSettings } from '../../api';
+import { useSnackbar } from '../../contexts/SnackbarContext';
+
+const VALID_NAME_REGEX = /^[A-Za-z0-9_]+$/;
+
+function PrefsVariables() {
+  const { addSnackMessage } = useSnackbar();
+  const [variables, setVariables] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newValue, setNewValue] = useState('');
+  const [nameError, setNameError] = useState('');
+
+  useEffect(() => {
+    loadVariables();
+  }, []);
+
+  const loadVariables = async () => {
+    try {
+      setLoading(true);
+      const vars = await getInstanceSetting('variables');
+      setVariables((vars as Record<string, string>) ?? {});
+    } catch (error) {
+      console.error('Failed to load variables:', error);
+      addSnackMessage('Failed to load variables', { severity: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const saveVariables = async (updated: Record<string, string>) => {
+    try {
+      setSaving(true);
+      await updateInstanceSettings({ variables: updated });
+      setVariables(updated);
+      addSnackMessage('Variables saved', { severity: 'success' });
+    } catch (error) {
+      console.error('Failed to save variables:', error);
+      addSnackMessage(`Failed to save variables: ${(error as Error).message}`, { severity: 'error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAdd = () => {
+    const trimmedName = newName.trim();
+    if (!trimmedName) {
+      setNameError('Name is required');
+      return;
+    }
+    if (!VALID_NAME_REGEX.test(trimmedName)) {
+      setNameError('Only letters, numbers, and underscores allowed');
+      return;
+    }
+    if (trimmedName in variables) {
+      setNameError('Variable already exists');
+      return;
+    }
+    setNameError('');
+    const updated = { ...variables, [trimmedName]: newValue };
+    setNewName('');
+    setNewValue('');
+    saveVariables(updated);
+  };
+
+  const handleDelete = (name: string) => {
+    const updated = { ...variables };
+    delete updated[name];
+    saveVariables(updated);
+  };
+
+  const handleValueChange = (name: string, value: string) => {
+    setVariables((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleValueBlur = (name: string) => {
+    saveVariables(variables);
+  };
+
+  const entries = Object.entries(variables).sort(([a], [b]) => a.localeCompare(b));
+
+  return (
+    <Box sx={{ padding: '20px', height: '100%' }}>
+      <Typography variant="h4">Build Action Variables</Typography>
+
+      <Box my={2} mx={1}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Global variables override default values defined in site model build actions.
+          Use these to configure machine-specific paths (e.g., executable locations)
+          without modifying shared model files. Variables are referenced as <code>%VARIABLE_NAME</code> in build action commands.
+        </Typography>
+
+        {entries.length > 0 ? (
+          <Table size="small" sx={{ mb: 3 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 'bold' }}>Name</TableCell>
+                <TableCell sx={{ fontWeight: 'bold' }}>Value</TableCell>
+                <TableCell width={48} />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {entries.map(([name, value]) => (
+                <TableRow key={name}>
+                  <TableCell>
+                    <code>{name}</code>
+                  </TableCell>
+                  <TableCell>
+                    <TextField
+                      value={value}
+                      onChange={(e) => handleValueChange(name, e.target.value)}
+                      onBlur={() => handleValueBlur(name)}
+                      size="small"
+                      fullWidth
+                      disabled={saving}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <IconButton
+                      size="small"
+                      onClick={() => handleDelete(name)}
+                      disabled={saving}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : !loading && (
+          <Box sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
+            <Typography variant="body2">
+              No variables defined. Add a variable to override build action defaults
+              for this machine.
+            </Typography>
+          </Box>
+        )}
+
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+          <TextField
+            label="Variable Name"
+            value={newName}
+            onChange={(e) => {
+              setNewName(e.target.value.toUpperCase());
+              setNameError('');
+            }}
+            size="small"
+            error={!!nameError}
+            helperText={nameError}
+            placeholder="e.g. NIX_EXEC"
+            disabled={loading || saving}
+          />
+          <TextField
+            label="Value"
+            value={newValue}
+            onChange={(e) => setNewValue(e.target.value)}
+            size="small"
+            placeholder="e.g. /usr/bin/nix"
+            disabled={loading || saving}
+            sx={{ flex: 1 }}
+          />
+          <Button
+            variant="outlined"
+            startIcon={<AddIcon />}
+            onClick={handleAdd}
+            disabled={loading || saving}
+            sx={{ mt: '1px' }}
+          >
+            Add
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+export default PrefsVariables;

--- a/packages/frontend/src/containers/WorkspaceMounted/Collection/CollectionItem.tsx
+++ b/packages/frontend/src/containers/WorkspaceMounted/Collection/CollectionItem.tsx
@@ -5,6 +5,8 @@ import { useCollectionItem, useWorkspaceDetails, useUpdateCollectionItem } from 
 import { siteQueryOptions } from './../../../queries/options';
 import { SukohForm } from './../../../components/SukohForm';
 import Spinner from './../../../components/Spinner';
+import { useSnackbar } from './../../../contexts/SnackbarContext';
+import * as api from './../../../api';
 import type { Field, BuildAction } from '@quiqr/types';
 
 interface CollectionItemProps {
@@ -53,6 +55,28 @@ function CollectionItem({ siteKey, workspaceKey, collectionKey, collectionItemKe
       );
     },
     [siteKey, workspaceKey, collectionKey, collectionItemKey, updateCollectionItemMutation]
+  );
+
+  const { addSnackMessage } = useSnackbar();
+
+  const handleDocBuild = useCallback(
+    async (buildAction: BuildAction) => {
+      const result = await api.buildCollectionItem(siteKey, workspaceKey, collectionKey, collectionItemKey, buildAction.key) as {
+        actionName: string;
+        stdoutType?: string;
+        stdoutContent: string;
+      };
+
+      addSnackMessage(`Build action "${result.actionName}" completed`, { severity: 'success' });
+
+      // If the build returns a file path, trigger a download
+      if (result.stdoutType === 'file_path' && result.stdoutContent) {
+        api.fileDownload(siteKey, workspaceKey, result.stdoutContent.trim());
+      }
+
+      return result;
+    },
+    [siteKey, workspaceKey, collectionKey, collectionItemKey, addSnackMessage]
   );
 
   const collection = selectedWorkspaceDetails?.collections.find((x) => x.key === collectionKey);
@@ -142,6 +166,7 @@ function CollectionItem({ siteKey, workspaceKey, collectionKey, collectionItemKe
       prompt_templates={prompt_templates}
       plugins={plugins}
       onSave={handleSave}
+      onDocBuild={handleDocBuild}
       onOpenInEditor={handleOpenInEditor}
       nestPath={nestPath}
     />

--- a/packages/frontend/src/containers/WorkspaceMounted/Single.tsx
+++ b/packages/frontend/src/containers/WorkspaceMounted/Single.tsx
@@ -5,6 +5,8 @@ import { useSingle, useWorkspaceDetails, useUpdateSingle } from './../../queries
 import { siteQueryOptions } from './../../queries/options';
 import { SukohForm } from './../../components/SukohForm';
 import Spinner from './../../components/Spinner';
+import { useSnackbar } from './../../contexts/SnackbarContext';
+import * as api from './../../api';
 import type { Field, BuildAction } from '@quiqr/types';
 
 interface SingleProps {
@@ -70,6 +72,28 @@ function Single({ siteKey, workspaceKey, singleKey, fileOverride, refreshed, mod
       );
     },
     [siteKey, workspaceKey, singleKey, updateSingleMutation]
+  );
+
+  const { addSnackMessage } = useSnackbar();
+
+  const handleDocBuild = useCallback(
+    async (buildAction: BuildAction) => {
+      const result = await api.buildSingle(siteKey, workspaceKey, singleKey, buildAction.key) as {
+        actionName: string;
+        stdoutType?: string;
+        stdoutContent: string;
+      };
+
+      addSnackMessage(`Build action "${result.actionName}" completed`, { severity: 'success' });
+
+      // If the build returns a file path, trigger a download
+      if (result.stdoutType === 'file_path' && result.stdoutContent) {
+        api.fileDownload(siteKey, workspaceKey, result.stdoutContent.trim());
+      }
+
+      return result;
+    },
+    [siteKey, workspaceKey, singleKey, addSnackMessage]
   );
 
   const single = selectedWorkspaceDetails?.singles.find((x) => x.key === singleKey);
@@ -152,6 +176,7 @@ function Single({ siteKey, workspaceKey, singleKey, fileOverride, refreshed, mod
       siteKey={siteKey}
       workspaceKey={workspaceKey}
       onSave={handleSave}
+      onDocBuild={handleDocBuild}
       onOpenInEditor={handleOpenInEditor}
       hideExternalEditIcon={single.hideExternalEditIcon}
       hideSaveButton={single.hideSaveButton}

--- a/packages/types/src/schemas/config.ts
+++ b/packages/types/src/schemas/config.ts
@@ -77,7 +77,13 @@ export const singleConfigSchema = z.object({
   pullOuterRootKey: z.string().optional(),
   fields: z.array(fieldSchema).optional(),
   prompt_templates: z.array(z.string()).optional(),
-  build_actions: z.array(buildActionSchema).optional()
+  build_actions: z.array(buildActionSchema).optional(),
+  // Accept camelCase variant from existing site models
+  buildActions: z.array(buildActionSchema).optional(),
+}).transform((data) => {
+  // Normalize camelCase buildActions to snake_case build_actions
+  const { buildActions, ...rest } = data;
+  return { ...rest, build_actions: rest.build_actions ?? buildActions };
 })
 
 export const collectionConfigSchema = z.object({
@@ -94,7 +100,13 @@ export const collectionConfigSchema = z.object({
   hidePreviewIcon: z.boolean().optional(),
   fields: z.array(fieldSchema),
   prompt_templates: z.array(z.string()).optional(),
-  build_actions: z.array(buildActionSchema).optional()
+  build_actions: z.array(buildActionSchema).optional(),
+  // Accept camelCase variant from existing site models
+  buildActions: z.array(buildActionSchema).optional(),
+}).transform((data) => {
+  // Normalize camelCase buildActions to snake_case build_actions
+  const { buildActions, ...rest } = data;
+  return { ...rest, build_actions: rest.build_actions ?? buildActions };
 })
 
 export const menuItemSchema = z.object({
@@ -478,6 +490,9 @@ export const instanceSettingsSchema = z.object({
     serveDraftMode: z.boolean().default(false),
     disableAutoHugoServe: z.boolean().default(false),
   }).default({ serveDraftMode: false, disableAutoHugoServe: false }),
+
+  // Global build action variables (machine-specific overrides for %VAR% substitution)
+  variables: z.record(z.string(), z.string()).default({}),
 
   // Authentication configuration (standalone mode only)
   auth: authConfigSchema.optional(),


### PR DESCRIPTION
- feature: restore build action buttons on single and collection forms with per-button loading state
- feature: auto-save before build action execution
- feature: build action console output panel with stdout/stderr display and truncation
- feature: file download endpoint for `stdout_type: file_path` build results (path-restricted to site directory)
- feature: global build action variables in instance settings, overriding YAML defaults
- feature: Variables section in Preferences UI for managing global build action variables
- feature: `QUIQR_DATA_DIR` env var to override standalone data directory
- feature: `HOST` / `BIND_ADDRESS` env var to control server bind address (for reverse proxy setups)
- feature: `QUIQR_CONFIG_FILE` env var to use an external config file (NixOS/Docker integration)
- feature: separate `runtime_state.json` for server-managed state (session secret), keeping `instance_settings.json` read-only
- fix: accept both `buildActions` (camelCase) and `build_actions` (snake_case) in site model YAML
- fix: global variables not persisted via Preferences UI (`updateInstanceSettings` missing `variables` merge)
- feature: unified frontend serving — standalone server serves both API and frontend from a single Express server
- feature: JWT-based authentication for standalone mode with local file user provider
- feature: login page, forced password change on first login, User menu with logout and change password
- feature: CLI user management tool (add, list, remove, reset-password)
- feature: Vite dev proxy for `/api` — frontend uses relative URLs in all modes
- feature: conditional CORS — disabled when serving frontend from same origin
- feature: SSE auth via query parameter for EventSource compatibility
- feature: first-run default admin user creation with console-printed credentials
- chore: Dockerfile updated to build and serve frontend, download embgit binary
- chore: docker-compose updated with Hugo preview port, persistent sites volume
- fix: openExternal graceful fallback to window.open() in standalone mode
- chore: upgrade to vite 8
